### PR TITLE
[Bugfix] CLDR data was not extracting properly into locales module

### DIFF
--- a/app/helpers/intl-get.js
+++ b/app/helpers/intl-get.js
@@ -33,7 +33,7 @@ else {
         var obj = intl.get(value);
 
         if (obj === undefined) {
-            throw new ReferenceError('Could not find Intl object: ' + path);
+            throw new ReferenceError('Could not find Intl object: ' + value);
         }
 
         return obj;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-intl",
   "description": "Ember toolbox for internationalization.",
-  "version": "1.0.0-rc5",
+  "version": "1.0.0-rc6",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -29,7 +29,6 @@
     "intl-messageformat": "1.0.4",
     "intl-relativeformat": "1.0.3",
     "intl": "0.1.4",
-    "recast": "^0.9.16",
     "serialize-javascript": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The CLDR data is now stored in “cldr” within the app container instead
of “locale”.  This is due to an issue within ember-cli where I was am
not able to processString over a file that already exists in the app
tree.

Ember-cli ends up just writing over it.