### PR TITLE
[Bugfix] Error when retrieving locale object

### DIFF
--- a/app/services/intl.js
+++ b/app/services/intl.js
@@ -168,7 +168,7 @@ export default ServiceKlass.extend(Ember.Evented, {
         }
 
         if (typeof locale === 'string') {
-            return this.container.lookup('locale:' + localeId.toLowerCase());
+            return this.container.lookup('locale:' + locale.toLowerCase());
         }
 
         throw new Error('`locale` must be a string or a locale instance');

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "serialize-javascript": "^1.0.0"
   },
   "devDependencies": {
+    "broccoli-merge-trees": "^0.2.1",
+    "broccoli-static-compiler": "^0.2.1",
     "ember-cli": "0.1.12",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "^0.3.1",


### PR DESCRIPTION
While readiing the intl.js file to check what I could use (or not) I found out that the `_getLocaleInstance` method used an unknown variable. 

I also added dependencies because while launching the test I encounter errors on the building phase. 