### PR TITLE
[Enhancement] Intl-get to handle computed properties as value

### DIFF
--- a/snippets/format-message.hbs
+++ b/snippets/format-message.hbs
@@ -4,6 +4,11 @@ Reference a message key, defined in your messages module corresponding to the cu
     product='Apple watch'
     price=200
     deadline=yesterday}}
+    
+{{format-message (intl-get computedProperty)
+    product='Apple watch'
+    price=200
+    deadline=yesterday}}
 
 Passing a static message or a message via a data-binding also works.
 

--- a/snippets/format-message.hbs
+++ b/snippets/format-message.hbs
@@ -16,3 +16,9 @@ Passing a static message or a message via a data-binding also works.
     name='Jason'
     numPhotos=num
     takenDate=yesterday}}
+    
+Use within bind-attr
+
+<button {{bind-attr title=(format-message (intl-get 'messages.product.title'))}}>
+    Hover to see title
+</button>

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -19,17 +19,9 @@ export default Ember.Controller.extend({
     messages: {
         photos: '{name} took {numPhotos, plural,\n  =0 {no photos}\n  =1 {one photo}\n  other {# photos}\n} on {takenDate, date, long}.\n'
     },
-
-    formatNumberPercent: computedNumber(400, { style: 'percent' }),
-    formatNumberSimple:  computedNumber(400),
-    formatNumberEuro:    computedNumber(400, 'EUR'),
-
-    formatMessageExample: Ember.computed('intl.locales', function () {
-        return this.intl.formatMessage(this.messages.photos, {
-            name:      'Jason',
-            numPhotos: 1400,
-            takenDate: now
-        });
+    
+    computedMessage: Ember.computed(function () {
+        return 'messages.product.info';
     }),
 
     incrementTime: Ember.on('init', function() {

--- a/tests/dummy/app/locales/en-us.js
+++ b/tests/dummy/app/locales/en-us.js
@@ -6,7 +6,8 @@ export default Locale.extend({
             info: '{product} will cost {price, number, EUR} if ordered by {deadline, date, time}',
             html: {
                 info: '<strong>{product}</strong> will cost <em>{price, number, EUR}</em> if ordered by {deadline, date, time}'
-            }
+            },
+            title: 'Hello world!'
         }
     }
 });

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -35,6 +35,10 @@
       numPhotos=num
       takenDate=yesterday}}
 </div>
+<br />
+<button {{bind-attr title=(format-message (intl-get 'messages.product.title'))}}>
+    Use with bind-attr
+</button>
 
 {{code-snippet name='format-message.hbs'}}
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -24,7 +24,7 @@
 <h3>Format Message</h3>
 
 <div>
-    {{format-message (intl-get 'messages.product.info')
+    {{format-message (intl-get computedMessage)
       product='Apple watch'
       price=200
       deadline=yesterday}}

--- a/tests/unit/format-message-test.js
+++ b/tests/unit/format-message-test.js
@@ -19,7 +19,8 @@ moduleForIntl('format-message', {
         container.register('locale:en', Locale.extend({
             messages: {
                 foo: {
-                    bar: "foo bar baz"
+                    bar: 'foo bar baz',
+                    baz: 'baz baz baz'
                 }
             }
         }));
@@ -146,6 +147,29 @@ test('locale can add message and intl-get can read it', function () {
     view = this.intlBlock('{{format-message (intl-get "messages.adding")}}');
     runAppend(view);
     equal(view.$().text(), "this works also");
+});
+
+test('intl-get handles bound computed property', function () {
+    expect(2);
+
+    view = this.intlBlock('{{format-message (intl-get computedMessage)}}');
+    
+    view.set('context', Ember.Controller.extend({
+        foo: true,
+        computedMessage: Ember.computed('foo', function () {
+            return this.get('foo') ? 'messages.foo.bar' : 'messages.foo.baz';
+        })
+    }).create());
+
+    runAppend(view);
+    
+    equal(view.$().text(), "foo bar baz");
+    
+    Ember.run(function () {
+        view.set('context.foo', false);
+    });
+    
+    equal(view.$().text(), "baz baz baz");
 });
 
 test('locale can add message to intl service and read it', function () {

--- a/tests/unit/format-message-test.js
+++ b/tests/unit/format-message-test.js
@@ -150,26 +150,37 @@ test('locale can add message and intl-get can read it', function () {
 });
 
 test('intl-get handles bound computed property', function () {
-    expect(2);
+    expect(3);
 
     view = this.intlBlock('{{format-message (intl-get computedMessage)}}');
-    
-    view.set('context', Ember.Controller.extend({
+
+    var context = Ember.Object.extend({
         foo: true,
         computedMessage: Ember.computed('foo', function () {
             return this.get('foo') ? 'messages.foo.bar' : 'messages.foo.baz';
         })
-    }).create());
+    }).create();
+
+
+    view.set('context', context);
 
     runAppend(view);
-    
+
     equal(view.$().text(), "foo bar baz");
-    
+
     Ember.run(function () {
         view.set('context.foo', false);
     });
-    
+
     equal(view.$().text(), "baz baz baz");
+
+    runDestroy(view);
+
+    Ember.run(function () {
+        context.set('foo', true);
+    });
+
+    ok(context, 'Updting binding to view after view is destroyed should not raise exception.');
 });
 
 test('locale can add message to intl service and read it', function () {


### PR DESCRIPTION
`{{format-message (intl-get computedProp)}}`

```js
computedProp: Ember.computed(function () {
  return ‘messages.foo’;
});
```

fixes #54 

I need to write some tests for this before it's merged.