### PR TITLE
`this` in helpers in Ember Canary is no longer the view

### DIFF
--- a/addon/helpers/base.js
+++ b/addon/helpers/base.js
@@ -28,10 +28,10 @@ export default function (formatterName) {
 
             var value     = params[0];
             var view      = env.data.view;
-            var intl      = this.container.lookup('intl:main');
+            var intl      = view.container.lookup('intl:main');
             var seenHash  = readHash(hash);
             var context   = view.get('context');
-            var formatter = this.container.lookup('formatter:' + formatterName);
+            var formatter = view.container.lookup('formatter:' + formatterName);
 
             if (value.isStream) {
                 value.subscribe(function (_stream) {

--- a/app/helpers/intl-get.js
+++ b/app/helpers/intl-get.js
@@ -11,14 +11,14 @@ function normalize (fullName) {
     return fullName.toLowerCase();
 }
 
-function intlGet (key, locale) {
+function intlGet (key, locale, container) {
     Ember.assert('You must pass in a message key in the form of a string.', typeof key === 'string');
 
-    var intl    = this.container.lookup('intl:main');
+    var intl    = container.lookup('intl:main');
     var locales = locale ? Ember.makeArray(locale) : intl.get('current');
 
     for (var i=0; i < locales.length; i++) {
-        var locale = this.container.lookup('locale:' + normalize(locales[i]));
+        var locale = container.lookup('locale:' + normalize(locales[i]));
 
         if (locale) {
             var value = locale.getValue(key);
@@ -36,8 +36,7 @@ export default function (value, options) {
     var view  = options.data.view;
     var types = options.types;
     var hash  = readHash(options.hash);
-    var intl  = this.container.lookup('intl:main');
-    var self  = this;
+    var intl  = view.container.lookup('intl:main');
 
     var currentValue = value;
     var valueStream, outStreamValue;
@@ -50,14 +49,14 @@ export default function (value, options) {
         outStreamValue = _value;
         this.notify();
     }
-    
+
     function valueStreamChanged () {
         currentValue = valueStream.value();
         pokeStream();
     }
 
     function pokeStream () {
-        outStream.setValue(intlGet.call(self, read(currentValue), hash.locales));
+        outStream.setValue(intlGet(read(currentValue), hash.locales, view.container));
     }
 
     if (types[0] === 'ID') {


### PR DESCRIPTION
Uses `env.data.view` to get the container, which has been available since 1.10.0-beta.1, so this is safe for all HTMLBars Ember versions.

See https://github.com/emberjs/ember.js/pull/10554 for context