### PR TITLE
[BREAKING] Removing intl injection into all popular types

### DIFF
--- a/addon/formatter-base.js
+++ b/addon/formatter-base.js
@@ -6,6 +6,8 @@
 import Ember from 'ember';
 
 var FormatBase = Ember.Object.extend({
+    intl: Ember.inject.service(),
+
     filterFormatOptions: function (hash) {
         hash = hash || {};
 

--- a/app/formatters/format-date.js
+++ b/app/formatters/format-date.js
@@ -9,7 +9,7 @@ import Formatter from 'ember-intl/formatter-base';
 var FormatDate = Formatter.extend({
     format: function (value, hash) {
         var options = this.filterFormatOptions(hash);
-        return this.intl.formatDate(value, options);
+        return this.get('intl').formatDate(value, options);
     }
 });
 

--- a/app/formatters/format-message.js
+++ b/app/formatters/format-message.js
@@ -26,7 +26,7 @@ var FormatMessage = Formatter.extend({
             formatOptions.locales = locales;
         }
 
-        return this.intl.formatMessage(value, hash, formatOptions);
+        return this.get('intl').formatMessage(value, hash, formatOptions);
     }
 });
 

--- a/app/formatters/format-number.js
+++ b/app/formatters/format-number.js
@@ -9,7 +9,7 @@ import Formatter from 'ember-intl/formatter-base';
 var FormatNumber = Formatter.extend({
     format: function (value, hash) {
         var options = this.filterFormatOptions(hash);
-        return this.intl.formatNumber(value, options);
+        return this.get('intl').formatNumber(value, options);
     }
 });
 

--- a/app/formatters/format-relative.js
+++ b/app/formatters/format-relative.js
@@ -10,7 +10,7 @@ var FormatRelative = Formatter.extend({
     format: function (value, hash) {
         var options = this.filterFormatOptions(hash);
 
-        return this.intl.formatRelative(value, options, {
+        return this.get('intl').formatRelative(value, options, {
             now: hash.now
         });
     }

--- a/app/formatters/format-time.js
+++ b/app/formatters/format-time.js
@@ -9,7 +9,7 @@ import Formatter from 'ember-intl/formatter-base';
 var FormatTime = Formatter.extend({
     format: function (value, hash) {
         var options = this.filterFormatOptions(hash);
-        return this.intl.formatTime(value, options);
+        return this.get('intl').formatTime(value, options);
     }
 });
 

--- a/app/initializers/ember-intl.js
+++ b/app/initializers/ember-intl.js
@@ -34,13 +34,6 @@ export var registerIntl = function (container) {
         instantiate: false
     });
 
-    container.injection('controller', 'intl', 'service:intl');
-    container.injection('component',  'intl', 'service:intl');
-    container.injection('route',      'intl', 'service:intl');
-    container.injection('model',      'intl', 'service:intl');
-    container.injection('view',       'intl', 'service:intl');
-    container.injection('formatter',  'intl', 'service:intl');
-
     if (!container.has('adapter:-intl-adapter')) {
         container.register('adapter:-intl-adapter', IntlAdapter);
     }

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,13 +1,14 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+    intl:      Ember.inject.service(),
     options:   ['en-US', 'fr-FR', 'es'],
 
     value: Ember.computed('intl.locales', function (key, value) {
         if (arguments.length === 2) {
-            this.intl.set('locales', arguments[1]);
+            this.set('intl.locales', arguments[1]);
         }
 
-        return this.intl.get('locales.firstObject') || this.intl.get('locales');
+        return this.get('intl.locales.firstObject') || this.get('intl.locales');
     })
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -5,11 +5,12 @@ var yesterday = now.setDate(now.getDate() - 1);
 
 function computedNumber (number, options) {
     return Ember.computed('intl.locales', function () {
-        return this.intl.formatNumber(number, options);
+        return this.get('intl').formatNumber(number, options);
     });
 }
 
 export default Ember.Controller.extend({
+    intl:      Ember.inject.service(),
     numType:   'currency',
     num:       1000,
     yesterday: yesterday,

--- a/tests/dummy/app/controllers/smoke.js
+++ b/tests/dummy/app/controllers/smoke.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+
 var Controller = Ember.Controller;
 var computed = Ember.computed;
 
@@ -7,6 +8,7 @@ var yesterday = new Date(now).setDate(now.getDate() - 1);
 
 
 export default Controller.extend({
+  intl:       Ember.inject.service(),
   locales:    ['en-US', 'fr-FR', 'es'],
   num:        1000,
   yesterday:  yesterday,


### PR DESCRIPTION
The alternative is to use `Ember.inject.service`:

```js
export default Ember.Component.extend({
  /* note: intl is a computed property so you must use
Ember.get/Ember.set to access */
  intl: Ember.inject.service()
})
```

fixes #80 