### PR TITLE
[Bugfix] Removing currentValue in base helper

### DIFF
--- a/addon/helpers/base.js
+++ b/addon/helpers/base.js
@@ -16,7 +16,7 @@ export default function (formatterName) {
             return throwError();
         }
 
-        var currentValue, outStream;
+        var outStream;
 
         function touchStream () {
             outStream.notify();
@@ -29,16 +29,13 @@ export default function (formatterName) {
         var formatter = view.container.lookup('formatter:' + formatterName);
 
         if (value.isStream) {
-            value.subscribe(function (_stream) {
-                currentValue = _stream.value();
+            value.subscribe(function () {
                 touchStream();
             }, value);
         }
 
-        currentValue = read(value);
-
         outStream = new Stream(function () {
-            return formatter.format.call(formatter, read(currentValue), seenHash);
+            return formatter.format.call(formatter, read(value), seenHash);
         });
 
         Ember.keys(hash).forEach(function (key) {


### PR DESCRIPTION
We faced problems that are generally related to base helper.

There is a `currentValue` variable in the `helpers/base.js`, which is used to store the current value obtained from input stream. This variable is not safe, as it can be used for writing and reading at the same time.
For example, we use the `format-number` helper to display the calculated values. In our case a user enters the initial values ​​in specific fields. As a result, the form displays incorrect calculated values. There is no problem if we don't apply formatting (using the plain output). Investigating the problem we noticed that the `currentValue` variable still stores previous value at the time of applying formats. The problem was resolved by getting rid of the `currentValue` variable and read values ​​directly from the input stream.

Thanks.