### PR TITLE
Remove Ember.Assert for IntlGetResult

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -6,7 +6,6 @@
 import Ember from 'ember';
 import { IntlMessageFormat } from '../utils/data';
 import createFormatCache from '../format-cache/memoizer';
-import IntlGetResult from '../models/intl-get-result';
 
 var makeArray    = Ember.makeArray;
 var get          = Ember.get;
@@ -136,8 +135,6 @@ export default Ember.Service.extend(Ember.Evented, {
         locales = locales ? makeArray(locales) : makeArray(get(this, 'locales'));
 
         var translation = this.get('adapter').findTranslation(locales, key);
-
-        Ember.assert('findTranslation should return an object of instance `IntlGetResult`', translation instanceof IntlGetResult);
 
         if (typeof translation === 'undefined') {
             throw new Error('translation: `' + key + '` on locale(s): ' + locales.join(',') + ' was not found.');


### PR DESCRIPTION
This will now display to others than they are missing a key in their
messages instead of a more cryptic message saying that a result is not
of type IntlGetResult.

Fixes issue #96.

Attempted to add a test to catch the case, but I test less than I should.  The `assert.throws` with a sub-expression seems not to pick up the error. Not sure if it's because the error happens in a different place than it's expecting due to it being a sub-expression.