### PR TITLE
Fix warnings to output locale code

### DIFF
--- a/lib/translation-blender.js
+++ b/lib/translation-blender.js
@@ -92,13 +92,14 @@ TranslationBlender.prototype.updateCache = function (includePaths, destDir) {
     var translationsSrc = includePaths[0];
     var outputPath = path.join(destDir, this.options.outputPath);
     var base = this.readAsObject(path.join(translationsSrc, baseLocale + '.json'));
-    var translation, filename;
+    var translation, filename, locale;
 
     mkdirp.sync(outputPath);
 
     walkSync(translationsSrc).forEach(function (file) {
         translation = this.readAsObject(path.join(translationsSrc, file));
-        this.report(translation, base, translation.locale);
+        locale = file.split('.')[0];
+        this.report(translation, base, locale);
         translation = extend(true, {}, base, translation);
         filename = path.join(outputPath, file.replace('.json', '.js'));
         fs.writeFileSync(filename, this.exportWrap(translation), { encoding: 'utf8' });


### PR DESCRIPTION
Fixes the issue where `undefined` is coming up instead of the specific
translation code.

I'm not sure if there is an easier way to parse the locale while in the broccoli merge-tree stuff. Just was taking a crack to hopefully help you move the 2.0 WIP branch.