### PR TITLE
Small patch to add ES6 deconstructor

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -83,18 +83,14 @@ export default Ember.Service.extend(Ember.Evented, {
         this.trigger('localesChanged');
     },
 
-    formatMessage(message, values, options) {
+    // Ignoring JSHint while waiting on jshint#1941
+    formatMessage(message, values, { locales = null, formats = get(this, 'formats') } = {}) { // jshint ignore:line
         // When `message` is a function, assume it's an IntlMessageFormat
         // instance's `format()` method passed by reference, and call it. This
         // is possible because its `this` will be pre-bound to the instance.
         if (typeof message === 'function') {
             return message(values);
         }
-
-        options = options || {};
-
-        let locales = options.locales;
-        let formats = options.formats || get(this, 'formats');
 
         if (isEmpty(locales)) {
             locales = get(this, 'locales');


### PR DESCRIPTION
Just a small patch to add the noted ES6 deconstructor. Feels a little
weird after using that pattern for so long.

JSHint current has an open issue for deconstructing throwing errors.
[#1941](https://github.com/jshint/jshint/issues/1941) will allow us to
remove the jshint ignore line.