### PR TITLE
Ember-try dependencies for older Embers

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -3,13 +3,15 @@ module.exports = {
     {
       name: 'Ember 1.10',
       dependencies: {
-        'ember': '1.10.0'
+        'ember': '1.10.0',
+        'ember-load-initializers': 'ember-cli/ember-load-initializers#0.0.2'
       }
     },
 		{
       name: 'Ember 1.11',
       dependencies: {
-        'ember': '1.11'
+        'ember': '1.11',
+        'ember-load-initializers': 'ember-cli/ember-load-initializers#0.0.2'
       }
     },
 		{


### PR DESCRIPTION
`ember-load-initializers#0.1.4` is incompatible with older versions of Ember. Just a concept to see if this is how to test old versions or if there is a workaround needed for the undefined initializers.