### PR TITLE
Pin Ember to 1.12.x until ready for 1.13

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "^1.12.1",
+    "ember": "~1.12.1",
     "ember-resolver": "~0.1.15",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",


### PR DESCRIPTION
Currently, the caret will allow Ember to upgrade to 1.13 which causes all sorts of failed tests. This fixes that by being more specific.