### PR TITLE
Fix ember-new-computed module not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "mkdirp": "^0.5.0",
     "object.assign": "^1.1.1",
     "serialize-javascript": "^1.0.0",
-    "walk-sync": "^0.1.3"
+    "walk-sync": "^0.1.3",
+    "ember-new-computed": "^1.0.1"
   },
   "devDependencies": {
     "ember-cli": "0.2.7",
@@ -58,7 +59,6 @@
     "ember-code-snippet": "^1.1.0",
     "ember-disable-prototype-extensions": "^1.0.1",
     "ember-disable-proxy-controllers": "^1.0.0",
-    "ember-new-computed": "^1.0.1",
     "ember-template-compiler": "*1.9.0-alpha",
     "ember-try": "0.0.7",
     "phantomjs-polyfill": "0.0.1"


### PR DESCRIPTION
`ember-new-computed` needs to be a dependency instead of a devDependency.

Fixes issue #133.