### PR TITLE
[Enhancement] support dasherized format options

### DIFF
--- a/addon/formatters/-base.js
+++ b/addon/formatters/-base.js
@@ -6,21 +6,26 @@
 import Ember from 'ember';
 
 var get = Ember.get;
+var a = Ember.A;
+var camelize = Ember.String.camelize;
 
 var FormatBase = Ember.Object.extend({
     filterFormatOptions(hash = {}) {
+        let formatOptions = this.constructor.formatOptions;
+        let camelizedKey = null;
         let match = false;
-        let options = this.constructor.formatOptions.reduce((opts, name) => {
-            if (hash.hasOwnProperty(name)) {
-                match = true;
-                opts[name] = hash[name];
-            }
+        let out = {};
 
-            return opts;
-        }, {});
+        for (var key in hash) {
+            camelizedKey = camelize(key);
+            if (formatOptions.contains(camelizedKey)) {
+                match = true;
+                out[camelizedKey] = hash[key];
+            }
+        }
 
         if (match) {
-            return options;
+            return out;
         }
     },
 
@@ -38,8 +43,8 @@ var FormatBase = Ember.Object.extend({
 });
 
 FormatBase.reopenClass({
-    formatOptions: Ember.A(['locale', 'format']),
-    concatenatedProperties: Ember.A(['formatOptions'])
+    formatOptions: a(['locale', 'format']),
+    concatenatedProperties: a(['formatOptions'])
 });
 
 export default FormatBase;

--- a/addon/formatters/format-time.js
+++ b/addon/formatters/format-time.js
@@ -3,36 +3,10 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import Ember from 'ember';
-import computed from 'ember-new-computed';
-import Formatter from './-base';
-import createFormatCache from '../format-cache/memoizer';
+import FormatDateFormatter from './format-date';
 
-function assertIsDate (date, errMsg) {
-    Ember.assert(errMsg, isFinite(date));
-}
-
-var FormatTime = Formatter.extend({
-    formatType: 'time',
-
-    formatter: computed(() => {
-        return createFormatCache(Intl.DateTimeFormat);
-    }).readOnly(),
-
-    format(value, options) {
-        value = new Date(value);
-        assertIsDate(value, 'A date or timestamp must be provided to format-time');
-        let formatOptions = this.filterFormatOptions(options);
-        return this._format(value, formatOptions);
-    }
-});
-
-FormatTime.reopenClass({
-    formatOptions: Ember.A([
-        'localeMatcher', 'timeZone', 'hour12', 'formatMatcher', 'weekday',
-        'era', 'year', 'month', 'day', 'hour', 'minute', 'second',
-        'timeZoneName'
-    ])
+var FormatTime = FormatDateFormatter.extend({
+    formatType: 'time'
 });
 
 export default FormatTime;

--- a/tests/unit/format-number-test.js
+++ b/tests/unit/format-number-test.js
@@ -87,7 +87,6 @@ test('should return a decimal as a string', function(assert) {
     assert.equal(view.$().text(), '4.004');
 });
 
-
 test('should return a formatted string with a thousand separator', function(assert) {
     assert.expect(1);
     view = this.intlBlock('{{format-number NUM}}', { locale: 'en-us' });
@@ -177,6 +176,13 @@ test('should function within an `each` block helper', function(assert) {
 test('should be able to combine hash options with format options', function(assert) {
     assert.expect(1);
     view = this.intlBlock('{{format-number 1 format="digits" minimumIntegerDigits=10}}', { locale: 'en-us' });
+    runAppend(view);
+    assert.equal(view.$().text(), '0,000,000,001.00', 'should return a string formatted to a percent');
+});
+
+test('should be able to combine hash options with format options with dasherized options name', function(assert) {
+    assert.expect(1);
+    view = this.intlBlock('{{format-number 1 format="digits" minimum-integer-digits=10}}', { locale: 'en-us' });
     runAppend(view);
     assert.equal(view.$().text(), '0,000,000,001.00', 'should return a string formatted to a percent');
 });


### PR DESCRIPTION
`{{format-time time-zone-name=‘foo’}}`