### PR TITLE
intl-get-result -> translation-lookup

### DIFF
--- a/addon/adapters/-intl-adapter.js
+++ b/addon/adapters/-intl-adapter.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import Translation from '../models/translation';
-import IntlGetResult from '../models/intl-get-result';
+import TranslationLookup from '../models/translation-lookup';
 
 function normalize (fullName) {
     Ember.assert('Lookup name must be a string', typeof fullName === 'string');
@@ -32,7 +32,7 @@ export default Ember.Object.extend({
                 translation = translations.getValue(translationKey);
 
                 if (typeof translation !== 'undefined') {
-                    return new IntlGetResult(translation, key);
+                    return new TranslationLookup(translation, key);
                 }
             }
         }

--- a/addon/formatters/format-message.js
+++ b/addon/formatters/format-message.js
@@ -8,7 +8,7 @@ import computed from 'ember-new-computed';
 import createFormatCache from 'intl-format-cache';
 import IntlMessageFormat from 'intl-messageformat';
 import Formatter from './-base';
-import IntlGetResult from '../models/intl-get-result';
+import TranslationLookup from '../models/translation-lookup';
 
 var get = Ember.get;
 
@@ -25,18 +25,19 @@ var FormatMessage = Formatter.extend({
         let locale = options.locale;
         let formatter = get(this, 'formatter');
 
-        if (value instanceof IntlGetResult) {
+        if (value && value instanceof TranslationLookup) {
             if (typeof locale === 'undefined') {
                 locale = value.locale;
             }
-            value = value.content;
+            value = value.translation;
         }
 
-        if (typeof value === 'function') {
+        const valueType = typeof value;
+
+        if (valueType === 'function') {
             return value(options);
         }
-
-        if (typeof value === 'string') {
+        else if (valueType === 'string') {
             value = formatter(value, locale, get(this, 'intl.formats'));
         }
 

--- a/addon/models/intl-get-result.js
+++ b/addon/models/intl-get-result.js
@@ -1,6 +1,0 @@
-function IntlGetResult (content, locale) {
-    this.content = content;
-    this.locale  = locale;
-}
-
-export default IntlGetResult;

--- a/addon/models/translation-lookup.js
+++ b/addon/models/translation-lookup.js
@@ -1,0 +1,10 @@
+function TranslationLookup (translation, locale) {
+    if (arguments.length < 2) {
+        throw new Error('Translation and associated locale name is required');
+    }
+
+    this.translation = translation;
+    this.locale = locale;
+}
+
+export default TranslationLookup;


### PR DESCRIPTION
`intl-get-result` naming no longer makes sense in the context which it is used.