### PR TITLE
CLDR data should also be driven by the new `included` options

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+		makeArray: require('./make-array'),
+		uniqueByString: require('./unique-by-string'),
+		lowercaseTree: require('./lowercase-tree')
+}

--- a/lib/utils/lowercase-tree.js
+++ b/lib/utils/lowercase-tree.js
@@ -1,0 +1,9 @@
+var rename = require('broccoli-stew').rename;
+
+function lowercaseTree(tree) {
+    return rename(tree, function(filepath) {
+        return filepath.toLowerCase();
+    });
+}
+
+module.exports = lowercaseTree;

--- a/lib/utils/make-array.js
+++ b/lib/utils/make-array.js
@@ -1,0 +1,13 @@
+function makeArray(arr) {
+    if (typeof arr === 'undefined') {
+        return [];
+    }
+
+    if (!Array.isArray(arr)) {
+        return [arr];
+    }
+
+    return arr;
+}
+
+module.exports = makeArray;

--- a/lib/utils/unique-by-string.js
+++ b/lib/utils/unique-by-string.js
@@ -1,0 +1,19 @@
+var makeArray = require('./make-array');
+
+function uniqueByString(array) {
+    var found = Object.create(null);
+    var out = [];
+
+    makeArray(array).forEach(function(item) {
+        if (typeof item !== 'string' || found[item.toLowerCase()]) {
+            return;
+        }
+
+        out.push(item);
+        found[item.toLowerCase()] = true;
+    });
+
+    return out;
+}
+
+module.exports = uniqueByString;


### PR DESCRIPTION
In the event that the consumer is side-loading their translations, we're unable to determine the CLDRs that need to be brought into the application at build time.  The way we now handle this is allowing the user to configure which CLDRs they want to bring into the application via:

```js
config/environment.js
intl: {
  locales: ['en-us', 'es-es', 'fr-fr']
}
```

en-us, es-es, fr-fr polyfill data and cldr data will brought into the application