### PR TITLE
Deprecate addMessage/addMessages, hash lookup instead of array lookup, renaming private methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Open, or create, `app/routes/application.js` and in the `beforeModel` hook set `
       // define the app's runtime locale
       // For example, here you would maybe do an API lookup to resolver
       // which locale the user should be targeted and perhaps lazily
-      // load translations using XHR and calling intl's `addMessage`/`addMessages`
+      // load translations using XHR and calling intl's `addTranslation`/`addTranslations`
       // method with the results of the XHR request
       this.set('intl.locale', 'en-us');
     }

--- a/addon/adapters/-intl-adapter.js
+++ b/addon/adapters/-intl-adapter.js
@@ -1,8 +1,15 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
 import Ember from 'ember';
 import Translation from '../models/translation';
 
+const { assert } = Ember;
+
 function normalize (fullName) {
-    Ember.assert('Lookup name must be a string', typeof fullName === 'string');
+    assert('Lookup name must be a string', typeof fullName === 'string');
     return fullName.toLowerCase();
 }
 

--- a/addon/formatters/-base.js
+++ b/addon/formatters/-base.js
@@ -4,33 +4,39 @@
  */
 
 import Ember from 'ember';
+import arrayToHash from '../utils/array-to-hash';
 
 const get = Ember.get;
 const camelize = Ember.String.camelize;
 
 let FormatBase = Ember.Object.extend({
+    init() {
+        this._super(...arguments);
+        this.options = arrayToHash(this.constructor.supportedOptions);
+    },
+
     /**
-    * Filters out all of the whitelisted formatter options from an Object.
+    * Filters out all of the whitelisted formatter options
     *
-    * @method filterWhitelistedOptions
+    * @method filterSupporedOptions
     * @param {Object} Options object
     * @return {Object} Options object containing just whitelisted options
+    * @private
     */
-    filterWhitelistedOptions(input = {}) {
-        let formatOptions = this.constructor.formatOptions;
+    filterSupporedOptions(input = {}) {
         let camelizedKey = null;
-        let match = false;
-        let out = {};
+        let foundMatch   = false;
+        const out = {};
 
         for (let key in input) {
             camelizedKey = camelize(key);
-            if (Ember.A(formatOptions).contains(camelizedKey)) {
-                match = true;
+            if (this.options[camelizedKey]) {
+                foundMatch = true;
                 out[camelizedKey] = input[key];
             }
         }
 
-        if (match) {
+        if (foundMatch) {
             return out;
         }
     },
@@ -44,24 +50,23 @@ let FormatBase = Ember.Object.extend({
     * @return {Object} Format options hash
     * @private
     */
-    _format(value, options = {}, formatOptions = {}) {
-        let formatter = get(this, 'formatter');
-        let { locale } = options;
+    _format(value, formatterOptions = {}, formatOptions = {}) {
+        const formatter  = get(this, 'formatter');
+        const { locale } = formatterOptions;
 
         if (!locale) {
-            throw new Error(`
-                No locale specified.  This is typically done application wide within routes/application.js
-                you can read how to configure it here: https://github.com/yahoo/ember-intl/blob/master/README.md#configure-application-wide-locale
-            `);
+            throw new Error(
+                `No locale specified.  This is typically done application-wide within routes/application.js. Instructions: https://github.com/yahoo/ember-intl/blob/master/README.md#configure-application-wide-locale`
+            );
         }
 
-        return formatter(locale, options).format(value, formatOptions);
+        return formatter(locale, formatterOptions).format(value, formatOptions);
     }
 });
 
 FormatBase.reopenClass({
-    formatOptions: ['locale', 'format'],
-    concatenatedProperties: ['formatOptions']
+    supportedOptions: ['locale', 'format'],
+    concatenatedProperties: ['supportedOptions']
 });
 
 export default FormatBase;

--- a/addon/formatters/format-date.js
+++ b/addon/formatters/format-date.js
@@ -19,15 +19,15 @@ let FormatDate = Formatter.extend({
         return createFormatCache(Intl.DateTimeFormat);
     }).readOnly(),
 
-    format(value, options = {}) {
+    format(value, options) {
         value = new Date(value);
         assertIsDate(value, 'A date or timestamp must be provided to format-date');
-        return this._format(value, this.filterWhitelistedOptions(options));
+        return this._format(value, this.filterSupporedOptions(options));
     }
 });
 
 FormatDate.reopenClass({
-    formatOptions: [
+    supportedOptions: [
         'localeMatcher', 'timeZone', 'hour12', 'formatMatcher', 'weekday',
         'era', 'year', 'month', 'day', 'hour', 'minute', 'second',
         'timeZoneName'

--- a/addon/formatters/format-html-message.js
+++ b/addon/formatters/format-html-message.js
@@ -8,10 +8,8 @@ import FormatterMessage from './format-message';
 
 let FormatHtmlMessage = FormatterMessage.extend({
     escapeProps(options = {}) {
-        let value;
-
         return Object.keys(options).reduce((result, hashKey) => {
-            value = options[hashKey];
+            let value = options[hashKey];
 
             if (typeof value === 'string') {
                 value = Ember.Handlebars.Utils.escapeExpression(value);
@@ -22,10 +20,9 @@ let FormatHtmlMessage = FormatterMessage.extend({
         }, {});
     },
 
-    format(value, options = {}) {
-        let locale = options.locale;
-        options = this.escapeProps(options);
-        let superResult = this._super(value, options, locale);
+    format(value, formatOptions = {}) {
+        const options     = this.escapeProps(formatOptions);
+        const superResult = this._super(value, options, formatOptions.locale);
         return Ember.String.htmlSafe(superResult);
     }
 });

--- a/addon/formatters/format-message.js
+++ b/addon/formatters/format-message.js
@@ -21,9 +21,9 @@ let FormatMessage = Formatter.extend({
     }).readOnly(),
 
     format(value, options = {}) {
-        let locale    = options.locale;
-        let formatter = get(this, 'formatter');
-        let valueType = typeof value;
+        const locale    = options.locale;
+        const formatter = get(this, 'formatter');
+        const valueType = typeof value;
 
         if (valueType === 'function') {
             return value(options);

--- a/addon/formatters/format-number.js
+++ b/addon/formatters/format-number.js
@@ -15,12 +15,12 @@ let FormatNumber = Formatter.extend({
     }).readOnly(),
 
     format(value, options) {
-        return this._format(value, this.filterWhitelistedOptions(options));
+        return this._format(value, this.filterSupporedOptions(options));
     }
 });
 
 FormatNumber.reopenClass({
-    formatOptions: [
+    supportedOptions: [
         'localeMatcher', 'style', 'currency', 'currencyDisplay',
         'useGrouping', 'minimumIntegerDigits', 'minimumFractionDigits',
         'maximumFractionDigits', 'minimumSignificantDigits',

--- a/addon/formatters/format-relative.js
+++ b/addon/formatters/format-relative.js
@@ -23,14 +23,14 @@ let FormatRelative = Formatter.extend({
     format(value, options = {}) {
         value = new Date(value);
         assertIsDate(value, 'A date or timestamp must be provided to format-relative');
-        return this._format(value, this.filterWhitelistedOptions(options), {
+        return this._format(value, this.filterSupporedOptions(options), {
             now: options.now
         });
     }
 });
 
 FormatRelative.reopenClass({
-    formatOptions: ['style', 'units']
+    supportedOptions: ['style', 'units']
 });
 
 export default FormatRelative;

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -31,8 +31,8 @@ export default function (formatType) {
             }
 
             let format = {};
-            let value = params[0];
-            let intl = Ember.get(this, 'intl');
+            let value  = params[0];
+            let intl   = Ember.get(this, 'intl');
 
             if (hash && hash.format) {
                 format = intl.getFormat(formatType, hash.format);

--- a/addon/models/locale.js
+++ b/addon/models/locale.js
@@ -1,8 +1,15 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
 import Ember from 'ember';
 import Translation from './translation';
 
+const { Logger:emberLogger } = Ember;
+
 export default Translation.extend({
     init() {
-        Ember.Logger.warn('`ember-intl/models/locale` is deprecated in favor of `ember-intl/models/translation`');
+        emberLogger.warn('`ember-intl/models/locale` is deprecated in favor of `ember-intl/models/translation`');
     }
 });

--- a/addon/models/translation.js
+++ b/addon/models/translation.js
@@ -5,25 +5,35 @@
 
 import Ember from 'ember';
 
-const { get, set } = Ember;
+const { get, set, Logger:emberLogger } = Ember;
 
 let TranslationModel = Ember.Object.extend({
-    addMessage(key, value) {
+    addTranslation(key, value) {
         set(this, key, value);
         return value;
     },
 
-    addMessages(messageObject) {
-        let messages = this;
+    addTranslations(messageObject) {
+      let messages = this;
 
-        // shallow merge intentional
-        for (let key in messageObject) {
-            if (messageObject.hasOwnProperty(key)) {
-                messages[key] = messageObject[key];
-            }
-        }
+      // shallow merge intentional
+      for (let key in messageObject) {
+          if (messageObject.hasOwnProperty(key)) {
+              messages[key] = messageObject[key];
+          }
+      }
 
-        return messages;
+      return messages;
+    },
+
+    addMessage() {
+        emberLogger.warn('`addMessage` is deprecated in favor of `addTranslation`');
+        return this.addTranslation(...arguments);
+    },
+
+    addMessages() {
+        emberLogger.warn('`addMessages` is deprecated in favor of `addTranslations`');
+        return this.addTranslations(...arguments);
     },
 
     // Exposes an accesor on the locale modules

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -8,15 +8,16 @@ import computed from 'ember-new-computed';
 import extend from '../utils/extend';
 import Translation from '../models/translation';
 
-const { makeArray, observer, get, set, run, Service, Evented, Logger } = Ember;
+const { makeArray, observer, get, set, run, Service, Evented, Logger:emberLogger } = Ember;
 const { once:runOnce } = run;
+const { warn } = emberLogger;
 
 function formatterProxy (formatType) {
     return function (value, options = {}) {
-        let formatter = this.container.lookup(`ember-intl@formatter:format-${formatType}`);
+        const formatter = this.container.lookup(`ember-intl@formatter:format-${formatType}`);
 
         if (typeof options.format === 'string') {
-            let format = this.getFormat(formatType, options.format);
+            const format = this.getFormat(formatType, options.format);
             options = extend(format, options);
         }
 
@@ -36,7 +37,7 @@ export default Service.extend(Evented, {
             return get(this, 'locale');
         },
         set(key, value) {
-            Logger.warn('`intl.locales` is deprecated in favor of `intl.locale`');
+            warn('`intl.locales` is deprecated in favor of `intl.locale`');
             set(this, 'locale', makeArray(value));
             return value;
         }
@@ -69,12 +70,12 @@ export default Service.extend(Evented, {
     }),
 
     addMessage() {
-        Logger.warn('`addMessage` is deprecated in favor of `addTranslation`');
+        warn('`addMessage` is deprecated in favor of `addTranslation`');
         return this.addTranslation(...arguments);
     },
 
     addMessages() {
-        Logger.warn('`addMessages` is deprecated in favor of `addTranslations`');
+        warn('`addMessages` is deprecated in favor of `addTranslations`');
         return this.addTranslations(...arguments);
     },
 
@@ -95,9 +96,9 @@ export default Service.extend(Evented, {
     },
 
     createLocale(locale, payload) {
-        let name = `ember-intl@translation:${locale}`;
         let container = this.container;
-        let instance = container.lookup('application:main') || {};
+        const name = `ember-intl@translation:${locale}`;
+        const instance = this.container.lookup('application:main') || {};
 
         if (instance.registry) {
             container = instance.registry;
@@ -111,7 +112,7 @@ export default Service.extend(Evented, {
     },
 
     getFormat(formatType, format) {
-        let formats = get(this, 'formats');
+        const formats = get(this, 'formats');
 
         if (formats && formatType && typeof format === 'string') {
             return get(formats, `${formatType}.${format}`) || {};
@@ -121,7 +122,7 @@ export default Service.extend(Evented, {
     },
 
     translationsFor(locale) {
-        let result = get(this, 'adapter').translationsFor(locale);
+        const result = get(this, 'adapter').translationsFor(locale);
 
         return Ember.RSVP.cast(result).then(function (localeInstance) {
             if (typeof localeInstance === 'undefined') {
@@ -134,7 +135,7 @@ export default Service.extend(Evented, {
 
     findTranslationByKey(key, locale) {
         locale = locale ? makeArray(locale) : makeArray(get(this, 'locale'));
-        let translation = get(this, 'adapter').findTranslationByKey(locale, key);
+        const translation = get(this, 'adapter').findTranslationByKey(locale, key);
 
         if (typeof translation === 'undefined') {
             throw new Error(`translation: '${key}' on locale(s): '${locale.join(',')}' was not found.`);

--- a/addon/utils/array-to-hash.js
+++ b/addon/utils/array-to-hash.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+function arrayToHash(array) {
+    const len = array.length;
+    const out = Object.create(null);
+    let i = 0;
+
+    for(;i < len; i++) {
+        const key = array[i];
+        out[key] = key;
+    }
+
+    return out;
+}
+
+export default arrayToHash;

--- a/addon/utils/extend.js
+++ b/addon/utils/extend.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
 import { extend } from 'intl-messageformat/utils';
 
 export default extend;

--- a/addon/utils/register-helper.js
+++ b/addon/utils/register-helper.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
 import Ember from 'ember';
 
 function registerHelper (name, klass, container) {

--- a/addon/utils/streams.js
+++ b/addon/utils/streams.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
 import Ember from 'ember';
 
 var Stream = Ember.__loader.require('ember-metal/streams/stream')['default'];

--- a/lib/locale-writer.js
+++ b/lib/locale-writer.js
@@ -13,9 +13,7 @@ var mkdirp        = require('mkdirp');
 var path          = require('path');
 var fs            = require('fs');
 
-if (!Object.assign) {
-    Object.assign = require('object.assign');
-}
+var assign        = require('./utils/assign');
 
 function LocaleWriter (inputTrees, outputPath, options) {
     if (!(this instanceof LocaleWriter)) {
@@ -28,7 +26,7 @@ function LocaleWriter (inputTrees, outputPath, options) {
 
     CachingWriter.call(this, inputTrees, options);
 
-    this.options = Object.assign({
+    this.options = assign({
         locales:        undefined,
         pluralRules:    false,
         relativeFields: false,

--- a/lib/utils/assign.js
+++ b/lib/utils/assign.js
@@ -1,0 +1,10 @@
+/**
+* Copyright 2015, Yahoo! Inc.
+* Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+*/
+
+if (typeof Object.assign !== 'function') {
+    Object.assign = require('object.assign');
+}
+
+module.exports = Object.assign;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,5 +1,12 @@
-module.exports = {
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+ module.exports = {
 		makeArray: require('./make-array'),
 		uniqueByString: require('./unique-by-string'),
-		lowercaseTree: require('./lowercase-tree')
+		lowercaseTree: require('./lowercase-tree'),
+		isModern: require('./is-modern'),
+		assign: require('./assign')
 }

--- a/lib/utils/is-modern.js
+++ b/lib/utils/is-modern.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+ var VersionChecker = require('ember-cli-version-checker');
+
+function isModern(instance) {
+    var checker = new VersionChecker(instance);
+    var dep     = checker.for('ember', 'bower');
+    return dep.satisfies('>= 1.13.0');
+}
+
+module.exports = isModern;

--- a/lib/utils/lowercase-tree.js
+++ b/lib/utils/lowercase-tree.js
@@ -1,4 +1,9 @@
-var rename = require('broccoli-stew').rename;
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+ var rename = require('broccoli-stew').rename;
 
 function lowercaseTree(tree) {
     return rename(tree, function(filepath) {

--- a/lib/utils/make-array.js
+++ b/lib/utils/make-array.js
@@ -1,4 +1,9 @@
-function makeArray(arr) {
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+ function makeArray(arr) {
     if (typeof arr === 'undefined') {
         return [];
     }

--- a/lib/utils/unique-by-string.js
+++ b/lib/utils/unique-by-string.js
@@ -1,4 +1,9 @@
-var makeArray = require('./make-array');
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+ var makeArray = require('./make-array');
 
 function uniqueByString(array) {
     var found = Object.create(null);

--- a/tests/unit/format-message-test.js
+++ b/tests/unit/format-message-test.js
@@ -147,7 +147,7 @@ test('intl-get returns message and format-message renders', function(assert) {
 test('locale can add message and intl-get can read it', function(assert) {
     assert.expect(1);
     const translation = this.container.lookup('ember-intl@translation:en-us');
-    translation.addMessage('adding', 'this works also');
+    translation.addTranslation('adding', 'this works also');
     view = this.render(hbs`{{format-message (intl-get "adding")}}`, { locale: 'en-us' });
     runAppend(view);
     assert.equal(view.$().text(), "this works also");
@@ -182,7 +182,7 @@ test('locale can add message to intl service and read it', function(assert) {
     assert.expect(1);
     run(() => {
         let service = this.container.lookup('service:intl');
-        service.addMessage('en-us', 'oh', 'hai!').then(() => {
+        service.addTranslation('en-us', 'oh', 'hai!').then(() => {
             view = this.render(hbs`{{format-message (intl-get "oh")}}`, { locale: 'en-us' });
             runAppend(view);
             assert.equal(view.$().text(), "hai!");
@@ -194,7 +194,7 @@ test('locale can add messages object and intl-get can read it', function(assert)
     assert.expect(1);
 
     const translation = this.container.lookup('ember-intl@translation:en-us');
-    translation.addMessages({
+    translation.addTranslations({
         'bulk-add': 'bulk add works'
     });
 


### PR DESCRIPTION
* Further deprecate addMessage/addMessages
* const where possible, hash lookup instead of array lookup
* call super on all the treeFor methods
* rename private methods for consistency