### PR TITLE
Remove observer and add exists lookup method

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Open, or create, `app/routes/application.js` and in the `beforeModel` hook set `
       // which locale the user should be targeted and perhaps lazily
       // load translations using XHR and calling intl's `addTranslation`/`addTranslations`
       // method with the results of the XHR request
-      this.set('intl.locale', 'en-us');
+      this.get('intl').setLocale('en-us');
     }
   });
 ```

--- a/README.md
+++ b/README.md
@@ -190,21 +190,21 @@ Formats [ICU Message][ICU] strings with the given values supplied as the hash ar
 
 ```
 You have {numPhotos, plural,
-	=0 {no photos.}
-	=1 {one photo.}
-	other {# photos.}}
+  =0 {no photos.}
+  =1 {one photo.}
+  other {# photos.}}
 ```
 
 ```hbs
 {{format-message (intl-get 'product.info')
-	product='Apple watch'
-	price=200
-	deadline=yesterday}}
+  product='Apple watch'
+  price=200
+  deadline=yesterday}}
 
 {{format-message boundProperty
-	name='Jason'
-	numPhotos=num
-	takenDate=yesterday}}
+  name='Jason'
+  numPhotos=num
+  takenDate=yesterday}}
 ```
 Or programmatically convert a message within any Ember Object.
 
@@ -223,12 +223,12 @@ This delegates to the `{{format-message}}` helper, but will first HTML-escape al
 
 ```hbs
 {{format-html-message (intl-get 'product.html.info')
-	product='Apple watch'
-	price=200
-	deadline=yesterday}}
+  product='Apple watch'
+  price=200
+  deadline=yesterday}}
 
 {{format-html-message '<strong>{numPhotos}</strong>'
-	numPhotos=(format-number num)}}
+  numPhotos=(format-number num)}}
 ```
 
 ### Intl-Get
@@ -236,9 +236,9 @@ Utility helper for returning the value, or eventual value, based on a translatio
 
 ```hbs
 {{format-message (intl-get 'product.info')
-	product='Apple watch'
-	price=200
-	deadline=yesterday}}
+  product='Apple watch'
+  price=200
+  deadline=yesterday}}
 ```
 
 Will return the message from the current locale, or locale explicitly passed as an argument, message object.
@@ -332,8 +332,8 @@ The solution is the ensure that the value you are passing in is in a format whic
 
 ### Helper Options
 * All helpers accept optional arguments:
-	* `locale` argument to explicitly pass/override the application locale
-	* `format` argument which you pass in a key corresponding to a format configuration in `app/formats.js`
+  * `locale` argument to explicitly pass/override the application locale
+  * `format` argument which you pass in a key corresponding to a format configuration in `app/formats.js`
 
 ## Writing Unit Tests
 

--- a/addon/adapters/-intl-adapter.js
+++ b/addon/adapters/-intl-adapter.js
@@ -6,7 +6,7 @@
 import Ember from 'ember';
 import Translation from '../models/translation';
 
-const { assert } = Ember;
+const { assert, makeArray } = Ember;
 
 function normalize (fullName) {
     assert('Lookup name must be a string', typeof fullName === 'string');
@@ -25,7 +25,7 @@ export default Ember.Object.extend({
     },
 
     findTranslationByKey(localeNames, translationKey) {
-        let locales = Ember.makeArray(localeNames);
+        let locales = makeArray(localeNames);
         let i = 0;
         let len = locales.length;
         let translations, translation, key;

--- a/addon/adapters/-intl-adapter.js
+++ b/addon/adapters/-intl-adapter.js
@@ -13,7 +13,7 @@ function normalize (fullName) {
     return fullName.toLowerCase();
 }
 
-export default Ember.Object.extend({
+const DefaultIntlAdapter = Ember.Object.extend({
     translationsFor(localeName) {
         if (localeName && localeName instanceof Translation) {
             return localeName;
@@ -42,3 +42,5 @@ export default Ember.Object.extend({
         }
     }
 });
+
+export default DefaultIntlAdapter;

--- a/addon/formatters/-base.js
+++ b/addon/formatters/-base.js
@@ -9,7 +9,7 @@ import arrayToHash from '../utils/array-to-hash';
 const get = Ember.get;
 const camelize = Ember.String.camelize;
 
-let FormatBase = Ember.Object.extend({
+const FormatBase = Ember.Object.extend({
     init() {
         this._super(...arguments);
         this.options = arrayToHash(this.constructor.supportedOptions);

--- a/addon/formatters/format-date.js
+++ b/addon/formatters/format-date.js
@@ -15,9 +15,11 @@ function assertIsDate (date, errMsg) {
 let FormatDate = Formatter.extend({
     formatType: 'date',
 
-    formatter: computed(() => {
-        return createFormatCache(Intl.DateTimeFormat);
-    }).readOnly(),
+    formatter: computed({
+        get() {
+            return createFormatCache(Intl.DateTimeFormat);
+        }
+    }),
 
     format(value, options) {
         value = new Date(value);

--- a/addon/formatters/format-date.js
+++ b/addon/formatters/format-date.js
@@ -8,11 +8,13 @@ import computed from 'ember-new-computed';
 import createFormatCache from 'intl-format-cache';
 import Formatter from './-base';
 
+const { assert } = Ember;
+
 function assertIsDate (date, errMsg) {
-    Ember.assert(errMsg, isFinite(date));
+    assert(errMsg, isFinite(date));
 }
 
-let FormatDate = Formatter.extend({
+const FormatDate = Formatter.extend({
     formatType: 'date',
 
     formatter: computed({

--- a/addon/formatters/format-html-message.js
+++ b/addon/formatters/format-html-message.js
@@ -6,13 +6,15 @@
 import Ember from 'ember';
 import FormatterMessage from './format-message';
 
-let FormatHtmlMessage = FormatterMessage.extend({
+const { String:emberString, Handlebars:emberHandlebars } = Ember;
+
+const FormatHtmlMessage = FormatterMessage.extend({
     escapeProps(options = {}) {
         return Object.keys(options).reduce((result, hashKey) => {
             let value = options[hashKey];
 
             if (typeof value === 'string') {
-                value = Ember.Handlebars.Utils.escapeExpression(value);
+                value = emberHandlebars.Utils.escapeExpression(value);
             }
 
             result[hashKey] = value;
@@ -23,7 +25,7 @@ let FormatHtmlMessage = FormatterMessage.extend({
     format(value, formatOptions = {}) {
         const options     = this.escapeProps(formatOptions);
         const superResult = this._super(value, options, formatOptions.locale);
-        return Ember.String.htmlSafe(superResult);
+        return emberString.htmlSafe(superResult);
     }
 });
 

--- a/addon/formatters/format-message.js
+++ b/addon/formatters/format-message.js
@@ -12,9 +12,11 @@ import Formatter from './-base';
 const { get } = Ember;
 
 let FormatMessage = Formatter.extend({
-    formatter: computed(() => {
-        return createFormatCache(IntlMessageFormat);
-    }).readOnly(),
+    formatter: computed({
+      get() {
+          return createFormatCache(IntlMessageFormat);
+      }
+    }),
 
     format(value, options, formats) {
         const { locale } = options;

--- a/addon/formatters/format-message.js
+++ b/addon/formatters/format-message.js
@@ -11,22 +11,17 @@ import Formatter from './-base';
 
 const { get } = Ember;
 
-let FormatMessage = Formatter.extend({
+const FormatMessage = Formatter.extend({
     formatter: computed({
-      get() {
-          return createFormatCache(IntlMessageFormat);
-      }
+        get() {
+            return createFormatCache(IntlMessageFormat);
+        }
     }),
 
     format(value, options, formats) {
         const { locale } = options;
-        const formatter = get(this, 'formatter');
-
-        if (typeof value === 'string') {
-            value = formatter(value, locale, formats);
-        }
-
-        return value.format(options);
+        const formatter  = get(this, 'formatter');
+        return formatter(value, locale, formats).format(options);
     }
 });
 

--- a/addon/formatters/format-number.js
+++ b/addon/formatters/format-number.js
@@ -7,7 +7,7 @@ import createFormatCache from 'intl-format-cache';
 import computed from 'ember-new-computed';
 import Formatter from './-base';
 
-let FormatNumber = Formatter.extend({
+const FormatNumber = Formatter.extend({
     formatType: 'number',
 
     formatter: computed({

--- a/addon/formatters/format-number.js
+++ b/addon/formatters/format-number.js
@@ -10,9 +10,11 @@ import Formatter from './-base';
 let FormatNumber = Formatter.extend({
     formatType: 'number',
 
-    formatter: computed(() => {
-        return createFormatCache(Intl.NumberFormat);
-    }).readOnly(),
+    formatter: computed({
+        get() {
+            return createFormatCache(Intl.NumberFormat);
+        }
+    }),
 
     format(value, options) {
         return this._format(value, this.filterSupporedOptions(options));

--- a/addon/formatters/format-relative.js
+++ b/addon/formatters/format-relative.js
@@ -16,9 +16,11 @@ function assertIsDate (date, errMsg) {
 let FormatRelative = Formatter.extend({
     formatType: 'relative',
 
-    formatter: computed(() => {
-        return createFormatCache(IntlRelativeFormat);
-    }).readOnly(),
+    formatter: computed({
+        get() {
+            return createFormatCache(IntlRelativeFormat);
+        }
+    }),
 
     format(value, options = {}) {
         value = new Date(value);

--- a/addon/formatters/format-relative.js
+++ b/addon/formatters/format-relative.js
@@ -9,8 +9,10 @@ import IntlRelativeFormat from 'intl-relativeformat';
 import createFormatCache from 'intl-format-cache';
 import Formatter from './-base';
 
-function assertIsDate (date, errMsg) {
-    Ember.assert(errMsg, isFinite(date));
+const { assert } = Ember;
+
+function assertIsDate(date, errMsg) {
+    assert(errMsg, isFinite(date));
 }
 
 let FormatRelative = Formatter.extend({
@@ -23,9 +25,9 @@ let FormatRelative = Formatter.extend({
     }),
 
     format(value, options = {}) {
-        value = new Date(value);
-        assertIsDate(value, 'A date or timestamp must be provided to format-relative');
-        return this._format(value, this.filterSupporedOptions(options), {
+        const dateValue = new Date(value);
+        assertIsDate(dateValue, 'A date or timestamp must be provided to format-relative');
+        return this._format(dateValue, this.filterSupporedOptions(options), {
             now: options.now
         });
     }

--- a/addon/formatters/format-time.js
+++ b/addon/formatters/format-time.js
@@ -5,7 +5,7 @@
 
 import FormatDateFormatter from './format-date';
 
-let FormatTime = FormatDateFormatter.extend({
+const FormatTime = FormatDateFormatter.extend({
     formatType: 'time'
 });
 

--- a/addon/helpers/-base-legacy.js
+++ b/addon/helpers/-base-legacy.js
@@ -72,10 +72,11 @@ export default function (formatType) {
         });
 
         view.one('willDestroyElement', () => {
+            intl.off('localeChanged', view, touchStream);
             destroyStream(outStream);
         });
 
-        intl.on('localeChanged', touchStream);
+        intl.on('localeChanged', view, touchStream);
 
         return outStream;
     };

--- a/addon/helpers/-base-legacy.js
+++ b/addon/helpers/-base-legacy.js
@@ -13,7 +13,9 @@ import {
     destroyStream
 } from 'ember-intl/utils/streams';
 
-export default function (formatType) {
+const { get } = Ember;
+
+const helperFactory = function (formatType) {
     function throwError () {
         return new Error(`${formatType} requires a single unname argument. {{format-${formatType} value}}`);
     }
@@ -52,8 +54,10 @@ export default function (formatType) {
             return formatter.format.call(
                 formatter,
                 read(value),
-                extend(Ember.getProperties(intl, 'locale'), format, seenHash),
-                Ember.get(intl, 'formats')
+                extend({
+                    locale: get(intl, '_locale')
+                }, format, seenHash),
+                get(intl, 'formats')
             );
         });
 
@@ -80,4 +84,6 @@ export default function (formatType) {
 
         return outStream;
     };
-}
+};
+
+export default helperFactory;

--- a/addon/helpers/-base-legacy.js
+++ b/addon/helpers/-base-legacy.js
@@ -46,7 +46,7 @@ export default function (formatType) {
             let format = {};
 
             if (seenHash && seenHash.format) {
-                format = intl.getFormat(formatType, seenHash.format);
+                format = intl.getFormat(formatType, seenHash.format) || {};
             }
 
             return formatter.format.call(

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -6,9 +6,9 @@
 import Ember from 'ember';
 import extend from '../utils/extend';
 
-const { get, getProperties } = Ember;
+const { get } = Ember;
 
-export default function (formatType) {
+const helperFactory = function (formatType) {
     function throwError () {
         return new Error(`${formatType} requires a single unname argument. {{format-${formatType} value}}`);
     }
@@ -45,9 +45,13 @@ export default function (formatType) {
 
             return this.formatter.format(
                 value,
-                extend(getProperties(intl, 'locale'), format, hash),
+                extend({
+                    locale: get(intl, '_locale')
+                }, format, hash),
                 get(intl, 'formats')
             );
         }
     });
-}
+};
+
+export default helperFactory;

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -6,7 +6,7 @@
 import Ember from 'ember';
 import extend from '../utils/extend';
 
-const { observer, get, getProperties } = Ember;
+const { get, getProperties } = Ember;
 
 export default function (formatType) {
     function throwError () {
@@ -19,12 +19,15 @@ export default function (formatType) {
 
         init() {
             this._super(...arguments);
+            const intl = get(this, 'intl');
             this.formatter = this.container.lookup(`ember-intl@formatter:format-${formatType}`);
+            intl.on('localeChanged', this, this.recompute);
         },
 
-        onIntlLocaleChanged: observer('intl.locale', function() {
-            this.recompute();
-        }),
+        willDestroy() {
+            const intl = get(this, 'intl');
+            intl.off('localeChanged', this, this.recompute);
+        },
 
         compute(params, hash) {
             if (!params || !params.length) {

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -36,7 +36,7 @@ export default function (formatType) {
             let format  = {};
 
             if (hash && hash.format) {
-                format = intl.getFormat(formatType, hash.format);
+                format = intl.getFormat(formatType, hash.format) || {};
             }
 
             return this.formatter.format(

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -24,9 +24,10 @@ export default function (formatType) {
             intl.on('localeChanged', this, this.recompute);
         },
 
-        willDestroy() {
+        destroy() {
             const intl = get(this, 'intl');
             intl.off('localeChanged', this, this.recompute);
+            return this._super(...arguments);
         },
 
         compute(params, hash) {

--- a/addon/helpers/intl-get-legacy.js
+++ b/addon/helpers/intl-get-legacy.js
@@ -12,14 +12,16 @@ import {
     destroyStream
 } from '../utils/streams';
 
+const { RSVP, assert } = Ember;
+
 // Backwards compatibility for Ember < 1.13
 export default function (value, options) {
-    Ember.assert('intl-get helper must be used as a subexpression', options.isInline === true);
+    assert('intl-get helper must be used as a subexpression', options.isInline === true);
 
-    let types = options.types;
-    let view = options.data.view;
-    let hash = readHash(options.hash);
-    let intl = view.container.lookup('service:intl');
+    const types = options.types;
+    const view = options.data.view;
+    const hash = readHash(options.hash);
+    const intl = view.container.lookup('service:intl');
 
     let currentValue = value;
     let outStreamValue = '';
@@ -40,7 +42,7 @@ export default function (value, options) {
     }
 
     function pokeStream () {
-        return Ember.RSVP.cast(intl.findTranslationByKey(read(currentValue), hash.locale)).then(function (translation) {
+        return RSVP.cast(intl.findTranslationByKey(read(currentValue), hash.locale)).then((translation) => {
             outStream.setValue(translation);
         });
     }

--- a/addon/helpers/intl-get.js
+++ b/addon/helpers/intl-get.js
@@ -18,10 +18,10 @@ if (Ember.Helper) {
             intl.on('localeChanged', this, this.recompute);
         },
 
-        willDestroy() {
-            this._super(...arguments);
+        destroy() {
             const intl = get(this, 'intl');
             intl.off('localeChanged', this, this.recompute);
+            return this._super(...arguments);
         },
 
         compute(params, hash = {}) {

--- a/addon/helpers/intl-get.js
+++ b/addon/helpers/intl-get.js
@@ -6,6 +6,7 @@
 import Ember from 'ember';
 
 const { get } = Ember;
+
 let Helper = null;
 
 if (Ember.Helper) {

--- a/addon/helpers/intl-get.js
+++ b/addon/helpers/intl-get.js
@@ -5,16 +5,24 @@
 
 import Ember from 'ember';
 
-const { observer, get } = Ember;
+const { get } = Ember;
 let Helper = null;
 
 if (Ember.Helper) {
     Helper = Ember.Helper.extend({
         intl: Ember.inject.service(),
 
-        onIntlLocaleChanged: observer('intl.locale', function() {
-            this.recompute();
-        }),
+        init() {
+            this._super(...arguments);
+            const intl = get(this, 'intl');
+            intl.on('localeChanged', this, this.recompute);
+        },
+
+        willDestroy() {
+            this._super(...arguments);
+            const intl = get(this, 'intl');
+            intl.off('localeChanged', this, this.recompute);
+        },
 
         compute(params, hash = {}) {
             const intl = get(this, 'intl');

--- a/addon/helpers/intl-get.js
+++ b/addon/helpers/intl-get.js
@@ -17,7 +17,8 @@ if (Ember.Helper) {
         }),
 
         compute(params, hash = {}) {
-            return get(this, 'intl').findTranslationByKey(params[0], hash.locale);
+            const intl = get(this, 'intl');
+            return intl.findTranslationByKey(params[0], hash.locale);
         }
     });
 }

--- a/addon/models/locale.js
+++ b/addon/models/locale.js
@@ -6,10 +6,10 @@
 import Ember from 'ember';
 import Translation from './translation';
 
-const { Logger:emberLogger } = Ember;
+const { Logger:logger } = Ember;
 
 export default Translation.extend({
     init() {
-        emberLogger.warn('`ember-intl/models/locale` is deprecated in favor of `ember-intl/models/translation`');
+        logger.warn('`ember-intl/models/locale` is deprecated in favor of `ember-intl/models/translation`');
     }
 });

--- a/addon/models/translation.js
+++ b/addon/models/translation.js
@@ -5,7 +5,7 @@
 
 import Ember from 'ember';
 
-const { get, set, Logger:emberLogger } = Ember;
+const { get, set, Logger:logger } = Ember;
 
 let TranslationModel = Ember.Object.extend({
     addTranslation(key, value) {
@@ -14,7 +14,7 @@ let TranslationModel = Ember.Object.extend({
     },
 
     addTranslations(messageObject) {
-      let messages = this;
+      const messages = this;
 
       // shallow merge intentional
       for (let key in messageObject) {
@@ -27,12 +27,12 @@ let TranslationModel = Ember.Object.extend({
     },
 
     addMessage() {
-        emberLogger.warn('`addMessage` is deprecated in favor of `addTranslation`');
+        logger.warn('`addMessage` is deprecated in favor of `addTranslation`');
         return this.addTranslation(...arguments);
     },
 
     addMessages() {
-        emberLogger.warn('`addMessages` is deprecated in favor of `addTranslations`');
+        logger.warn('`addMessages` is deprecated in favor of `addTranslations`');
         return this.addTranslations(...arguments);
     },
 

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -8,8 +8,7 @@ import computed from 'ember-new-computed';
 import extend from '../utils/extend';
 import Translation from '../models/translation';
 
-const { assert, get, set, RSVP, Service, Evented, Logger:emberLogger } = Ember;
-const { warn } = emberLogger;
+const { assert, get, set, RSVP, Service, Evented, Logger:logger } = Ember;
 
 function formatterProxy (formatType) {
     return function (value, options = {}) {
@@ -28,7 +27,7 @@ function formatterProxy (formatType) {
     };
 }
 
-export default Service.extend(Evented, {
+const IntlService = Service.extend(Evented, {
     _locale: null,
 
     locale: computed('_locale', {
@@ -41,9 +40,9 @@ export default Service.extend(Evented, {
     }),
 
     formatRelative: formatterProxy('relative'),
-    formatMessage: formatterProxy('message'),
-    formatNumber: formatterProxy('number'),
-    formatTime: formatterProxy('time'),
+    formatMessage : formatterProxy('message'),
+    formatNumber  : formatterProxy('number'),
+    formatTime    : formatterProxy('time'),
     formatDate: formatterProxy('date'),
 
     adapter: computed({
@@ -55,26 +54,28 @@ export default Service.extend(Evented, {
     formats: computed({
         get() {
             const formats = this.container.lookupFactory('formats:main');
+
             if (Ember.Object.detect(formats)) {
                 return formats.create();
             }
+
             return formats;
         }
     }),
 
     addMessage() {
-        warn('`addMessage` is deprecated in favor of `addTranslation`');
+        logger.warn('`addMessage` is deprecated in favor of `addTranslation`');
         return this.addTranslation(...arguments);
     },
 
     addMessages() {
-        warn('`addMessages` is deprecated in favor of `addTranslations`');
+        logger.warn('`addMessages` is deprecated in favor of `addTranslations`');
         return this.addTranslations(...arguments);
     },
 
     exists(key) {
       const locale = get(this, '_locale');
-      assert('Intl: Cannot check existance when locale is null', locale);
+      assert('ember-intl: Cannot check existance when locale is null || undefined', locale);
       return get(this, 'adapter').findTranslationByKey(locale, key);
     },
 
@@ -124,7 +125,7 @@ export default Service.extend(Evented, {
 
         return RSVP.cast(result).then(function (localeInstance) {
             if (typeof localeInstance === 'undefined') {
-                throw new Error('\'locale\' must be a string or a locale instance');
+                throw new Error(`'locale' must be a string or a locale instance`);
             }
 
             return localeInstance;
@@ -142,3 +143,5 @@ export default Service.extend(Evented, {
         return translation;
     }
 });
+
+export default IntlService;

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -8,7 +8,7 @@ import computed from 'ember-new-computed';
 import extend from '../utils/extend';
 import Translation from '../models/translation';
 
-const { makeArray, observer, get, set, run, Service, Evented, Logger:emberLogger } = Ember;
+const { assert, makeArray, observer, get, set, run, Service, Evented, Logger:emberLogger } = Ember;
 const { once:runOnce } = run;
 const { warn } = emberLogger;
 
@@ -79,6 +79,12 @@ export default Service.extend(Evented, {
         return this.addTranslations(...arguments);
     },
 
+    exists(key) {
+      const locale = this.get('locale');
+      assert('Intl: Cannot check existance when locale is null', locale);
+      return get(this, 'adapter').findTranslationByKey(locale, key);
+    },
+
     addTranslation(locale, key, value) {
         return this.translationsFor(locale).then((localeInstance) => {
             return localeInstance.addMessage(key, value);
@@ -115,10 +121,8 @@ export default Service.extend(Evented, {
         const formats = get(this, 'formats');
 
         if (formats && formatType && typeof format === 'string') {
-            return get(formats, `${formatType}.${format}`) || {};
+            return get(formats, `${formatType}.${format}`);
         }
-
-        return {};
     },
 
     translationsFor(locale) {
@@ -134,8 +138,8 @@ export default Service.extend(Evented, {
     },
 
     findTranslationByKey(key, locale) {
-        locale = locale ? makeArray(locale) : makeArray(get(this, 'locale'));
-        const translation = get(this, 'adapter').findTranslationByKey(locale, key);
+        const _locale = locale ? locale : get(this, 'locale');
+        const translation = get(this, 'adapter').findTranslationByKey(_locale, key);
 
         if (typeof translation === 'undefined') {
             throw new Error(`translation: '${key}' on locale(s): '${locale.join(',')}' was not found.`);

--- a/addon/utils/register-helper.js
+++ b/addon/utils/register-helper.js
@@ -5,7 +5,7 @@
 
 import Ember from 'ember';
 
-function registerHelper (name, klass, container) {
+function registerHelper(name, klass, container) {
     if (!Ember.Helper) {
         return Ember.HTMLBars._registerHelper(name, klass);
     }

--- a/addon/utils/streams.js
+++ b/addon/utils/streams.js
@@ -5,21 +5,25 @@
 
 import Ember from 'ember';
 
-var Stream = Ember.__loader.require('ember-metal/streams/stream')['default'];
+const {
+    __loader
+} = Ember;
+
+export const Stream = __loader.require('ember-metal/streams/stream')['default'];
 
 // The below read, readHash methods are from Ember.js
 // https://github.com/emberjs/ember.js/blob/master/packages/ember-metal/lib/streams/utils.js
 // License: https://github.com/emberjs/ember.js/blob/master/LICENSE
-function read (object) {
-    if (object && object.isStream) {
-        return object.value();
-    } else {
-        return object;
+export function read(obj) {
+    if (obj && obj.isStream) {
+        return obj.value();
     }
+
+    return obj;
 }
 
-export function readHash (object) {
-    let ret = {};
+export function readHash(object) {
+    const ret = {};
 
     for (var key in object) {
         ret[key] = read(object[key]);
@@ -28,18 +32,15 @@ export function readHash (object) {
     return ret;
 }
 
-function destroyStream (stream) {
+export function destroyStream(stream) {
     if (stream && !stream.destroyed) {
         stream.destroy();
     }
 }
 
-export var readHash = readHash;
-export var destroyStream = destroyStream;
-export var Stream = Stream;
-export var read = read;
-
 export default {
-    Stream: Stream,
-    read:   read
+    read,
+    readHash,
+    destroyStream,
+    Stream
 };

--- a/app/helpers/format-date.js
+++ b/app/helpers/format-date.js
@@ -1,1 +1,6 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
 export { default } from 'ember-intl/helpers/format-date';

--- a/app/helpers/format-html-message.js
+++ b/app/helpers/format-html-message.js
@@ -1,1 +1,6 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
 export { default } from 'ember-intl/helpers/format-html-message';

--- a/app/helpers/format-message.js
+++ b/app/helpers/format-message.js
@@ -1,1 +1,6 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
 export { default } from 'ember-intl/helpers/format-message';

--- a/app/helpers/format-number.js
+++ b/app/helpers/format-number.js
@@ -1,1 +1,6 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
 export { default } from 'ember-intl/helpers/format-number';

--- a/app/helpers/format-relative.js
+++ b/app/helpers/format-relative.js
@@ -1,1 +1,6 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
 export { default } from 'ember-intl/helpers/format-relative';

--- a/app/helpers/format-time.js
+++ b/app/helpers/format-time.js
@@ -1,1 +1,6 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
 export { default } from 'ember-intl/helpers/format-time';

--- a/blueprints/ember-intl/index.js
+++ b/blueprints/ember-intl/index.js
@@ -10,7 +10,7 @@ module.exports = {
 
     afterInstall: function() {
         this.ui.writeLine(
-            '[ember-intl] Don\'t forget to setup your application-wide locale.  ' +
+            'ember-intl: Don\'t forget to setup your application-wide locale.  ' +
             'The value of this is typically based on a user preference.  ' +
             'Documentation: https://github.com/yahoo/ember-intl#configure-application-wide-locale'
         );

--- a/blueprints/locale/index.js
+++ b/blueprints/locale/index.js
@@ -4,8 +4,8 @@
  */
 
 var broccoliCLDR = require('../../lib/locale-writer');
-var Blueprint   = require('ember-cli/lib/models/blueprint');
-var SilentError = require('ember-cli/lib/errors/silent');
+var Blueprint    = require('ember-cli/lib/models/blueprint');
+var SilentError  = require('ember-cli/lib/errors/silent');
 
 module.exports = {
     description: 'Extract CLDR data as an ES6 module for a given locale',

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,20 +7,20 @@ module.exports = {
         'ember-load-initializers': 'ember-cli/ember-load-initializers#0.0.2'
       }
     },
-		{
+    {
       name: 'ember-1.11.3',
       dependencies: {
         'ember': '1.11.3',
         'ember-load-initializers': 'ember-cli/ember-load-initializers#0.0.2'
       }
     },
-		{
+    {
       name: 'ember-1.12.0',
       dependencies: {
         'ember': '1.12'
       }
     },
-		{
+    {
       name: 'ember-1.13.5',
       dependencies: {
         'ember': '1.13.5'

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ module.exports = {
                 if (!has) {
                     this.ui.writeLine(
                         chalk.red(
-                            '[ember-intl] \'' + localeName + '\' does not match a supported locale name.\n' +
+                            'ember-intl: \'' + localeName + '\' does not match a supported locale name.\n' +
                             'List of supported locales: https://github.com/yahoo/formatjs-extract-cldr-data/tree/master/data/main'
                         )
                     );

--- a/lib/translation-blender.js
+++ b/lib/translation-blender.js
@@ -91,7 +91,7 @@ TranslationBlender.prototype.report = function (target, defaultTranslationKeys, 
 
     defaultTranslationKeys.forEach(function (property) {
         if (targetProps.indexOf(property) === -1) {
-            log(chalk.yellow('[ember-intl] \'' + property + '\' missing from ' + locale));
+            log(chalk.yellow('ember-intl: \'' + property + '\' missing from ' + locale));
         }
     });
 };
@@ -113,7 +113,7 @@ TranslationBlender.prototype.updateCache = function (includePaths, destDir) {
     })[0];
 
     if (!defaultTranslationPath) {
-        log(chalk.yellow('[ember-intl] "' + this.options.defaultLocale + '" default locale missing `translations` folder'));
+        log(chalk.yellow('ember-intl: "' + this.options.defaultLocale + '" default locale missing `translations` folder'));
         return;
     }
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -4,9 +4,9 @@
  */
 
  module.exports = {
-		makeArray: require('./make-array'),
-		uniqueByString: require('./unique-by-string'),
-		lowercaseTree: require('./lowercase-tree'),
-		isModern: require('./is-modern'),
-		assign: require('./assign')
+    makeArray: require('./make-array'),
+    uniqueByString: require('./unique-by-string'),
+    lowercaseTree: require('./lowercase-tree'),
+    isModern: require('./is-modern'),
+    assign: require('./assign')
 }

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -6,8 +6,8 @@ export default Ember.Controller.extend({
     locales: Ember.A(['en-us', 'fr-fr', 'es-es']),
 
     actions: {
-        changeLocale(localeName) {
-            this.set('intl.locale', localeName);
+        changeLocale(locale) {
+            this.get('intl').setLocale(locale);
         }
     }
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -7,7 +7,7 @@ let now       = new Date();
 let yesterday = now.setDate(now.getDate() - 1);
 
 function computedNumber (number, options) {
-    return computed('intl.locale', function () {
+    return computed('intl._locale', function () {
         return get(this, 'intl').formatNumber(number, options);
     });
 }

--- a/tests/dummy/app/controllers/smoke.js
+++ b/tests/dummy/app/controllers/smoke.js
@@ -11,8 +11,8 @@ export default Ember.Controller.extend({
   yesterday:  yesterday,
 
   actions: {
-      changeLocale(localeName) {
-          this.set('intl.locale', localeName);
+      changeLocale(locale) {
+          this.get('intl').setLocale(locale);
       }
   }
 });

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-	intl: Ember.inject.service(),
+    intl: Ember.inject.service(),
 
-	beforeModel() {
-		Ember.set(this, 'intl.locale', 'en-us');
-	}
+    beforeModel() {
+        this.get('intl').setLocale('en-us');
+    }
 });

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -36,7 +36,7 @@
       takenDate=yesterday}}
 </div>
 <br />
-<button title={{format-message (intl-get 'product.title')}}>
+<button {{bind-attr title=(format-message (intl-get 'product.title'))}}>
     Hover to see title
 </button>
 

--- a/tests/helpers/create-intl-block.js
+++ b/tests/helpers/create-intl-block.js
@@ -6,12 +6,12 @@
 import Ember from 'ember';
 
 function createIntlBlock (container) {
-    return (template, serviceContext) => {
-        let service = container.lookup('service:intl');
+    return (template, locale) => {
+        const service = container.lookup('service:intl');
 
-        if (typeof serviceContext === 'object') {
+        if (locale) {
             Ember.run(() => {
-                service.setProperties(serviceContext);
+                service.setLocale(locale);
             });
         }
 

--- a/tests/unit/format-date-test.js
+++ b/tests/unit/format-date-test.js
@@ -49,7 +49,7 @@ test('should throw if called with out a value', function(assert) {
 test('it should return a formatted string from a date string', function(assert) {
     assert.expect(1);
     // Must provide `timeZone` because: https://github.com/yahoo/ember-intl/issues/21
-    view = this.render(hbs`{{format-date date timeZone='UTC'}}`, {locale: 'en-us'});
+    view = this.render(hbs`{{format-date date timeZone='UTC'}}`, 'en-us');
     view.set('context', { date: date });
     runAppend(view);
     assert.equal(view.$().text(), '1/23/2014');
@@ -58,7 +58,7 @@ test('it should return a formatted string from a date string', function(assert) 
 test('it should return a formatted string from a timestamp', function(assert) {
     assert.expect(1);
     // Must provide `timeZone` because: https://github.com/yahoo/ember-intl/issues/21
-    view = this.render(hbs`{{format-date date timeZone='UTC'}}`, {locale: 'en-us'});
+    view = this.render(hbs`{{format-date date timeZone='UTC'}}`, 'en-us');
     view.set('context', { date: date });
     runAppend(view);
     assert.equal(view.$().text(), '1/23/2014');
@@ -66,7 +66,7 @@ test('it should return a formatted string from a timestamp', function(assert) {
 
 test('it should return a formatted string of just the date', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-date date hour='numeric' minute='numeric' timeZone='UTC'}}`, {locale: 'en-us'});
+    view = this.render(hbs`{{format-date date hour='numeric' minute='numeric' timeZone='UTC'}}`, 'en-us');
     view.set('context', { date: date });
     runAppend(view);
     assert.equal(view.$().text(), '11:00 PM');
@@ -75,7 +75,7 @@ test('it should return a formatted string of just the date', function(assert) {
 test('it should format the epoch timestamp', function(assert) {
     assert.expect(1);
     let locale = 'en-us';
-    view = this.render(hbs`{{format-date 0}}`, {locale: locale});
+    view = this.render(hbs`{{format-date 0}}`, locale);
     runAppend(view);
     assert.equal(view.$().text(), new Intl.DateTimeFormat(locale).format(0));
 });

--- a/tests/unit/format-html-message-test.js
+++ b/tests/unit/format-html-message-test.js
@@ -33,7 +33,7 @@ test('exists', function(assert) {
 
 test('message is formatted correctly with argument', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-html-message "Hello {name}" name="Jason"}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-html-message "Hello {name}" name="Jason"}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), "Hello Jason");
 });
@@ -41,26 +41,26 @@ test('message is formatted correctly with argument', function(assert) {
 test('should throw if called with out a value', function(assert) {
     assert.expect(1);
     view = this.render(hbs`{{format-html-message}}`);
-    assert.throws(runAppend(view), Error, 'raised error when not value is passed to format-html-message', { locale: 'en-us' });
+    assert.throws(runAppend(view), Error, 'raised error when not value is passed to format-html-message', 'en-us');
 });
 
 test('should allow for inlined html in the value', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-html-message "<strong>Hello {name}</strong>" name="Jason"}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-html-message "<strong>Hello {name}</strong>" name="Jason"}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().html(), "<strong>Hello Jason</strong>");
 });
 
 test('should escape arguments', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-html-message "{foo}" foo="<em>BAR</em>"}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-html-message "{foo}" foo="<em>BAR</em>"}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().html(), "&lt;em&gt;BAR&lt;/em&gt;");
 });
 
 test('should allow for inlined html in the value but escape arguments', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-html-message "<strong>Hello {name}</strong>" name="<em>Jason</em>"}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-html-message "<strong>Hello {name}</strong>" name="<em>Jason</em>"}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().html(), "<strong>Hello &lt;em&gt;Jason&lt;/em&gt;</strong>");
 });

--- a/tests/unit/format-message-test.js
+++ b/tests/unit/format-message-test.js
@@ -64,20 +64,20 @@ test('invoke formatMessage directly', function(assert) {
 
 test('message is formatted correctly with argument', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-message "Hello {name}" name="Jason"}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-message "Hello {name}" name="Jason"}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), "Hello Jason");
 });
 
 test('should throw if called with out a value', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-message}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-message}}`, 'en-us');
     assert.throws(runAppend(view), Error, 'raised error when not value is passed to format-message');
 });
 
 test('should return a formatted string', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-message MSG firstName=firstName lastName=lastName}}`, {locale: 'en-us'});
+    view = this.render(hbs`{{format-message MSG firstName=firstName lastName=lastName}}`, 'en-us');
     view.set('context', {
         MSG      : 'Hi, my name is {firstName} {lastName}.',
         firstName: 'Anthony',
@@ -89,7 +89,7 @@ test('should return a formatted string', function(assert) {
 
 test('should return a formatted string with formatted numbers and dates', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-message POP_MSG city=city population=population census_date=census_date timeZone=timeZone}}`, {locale: 'en-us'});
+    view = this.render(hbs`{{format-message POP_MSG city=city population=population census_date=census_date timeZone=timeZone}}`, 'en-us');
     view.set('context', {
         POP_MSG    : '{city} has a population of {population, number, integer} as of {census_date, date, long}.',
         city       : 'Atlanta',
@@ -103,7 +103,7 @@ test('should return a formatted string with formatted numbers and dates', functi
 
 test('should return a formatted string with formatted numbers and dates in a different locale', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-message POP_MSG city=city population=population census_date=census_date timeZone=timeZone}}`, {locale: 'de-de'});
+    view = this.render(hbs`{{format-message POP_MSG city=city population=population census_date=census_date timeZone=timeZone}}`, 'de-de');
     view.set('context', {
         POP_MSG    : '{city} hat eine Bevölkerung von {population, number, integer} zum {census_date, date, long}.',
         city       : 'Atlanta',
@@ -122,7 +122,7 @@ test('should return a formatted string with an `each` block', function(assert) {
       hbs`
         {{#each harvests as |harvest|}}{{format-message HARVEST_MSG person=harvest.person count=harvest.count}}{{/each}}
       `,
-      { locale: 'en-us' }
+      'en-us'
     );
 
     view.set('context', {
@@ -139,7 +139,7 @@ test('should return a formatted string with an `each` block', function(assert) {
 
 test('intl-get returns message and format-message renders', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-message (intl-get "foo.bar")}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-message (intl-get "foo.bar")}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), "foo bar baz");
 });
@@ -148,14 +148,14 @@ test('locale can add message and intl-get can read it', function(assert) {
     assert.expect(1);
     const translation = this.container.lookup('ember-intl@translation:en-us');
     translation.addTranslation('adding', 'this works also');
-    view = this.render(hbs`{{format-message (intl-get "adding")}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-message (intl-get "adding")}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), "this works also");
 });
 
 test('intl-get handles bound computed property', function(assert) {
     assert.expect(3);
-    view = this.render(hbs`{{format-message (intl-get computedMessage)}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-message (intl-get computedMessage)}}`, 'en-us');
     const context = Ember.Object.extend({
         foo: true,
         computedMessage: computed('foo', {
@@ -181,9 +181,9 @@ test('intl-get handles bound computed property', function(assert) {
 test('locale can add message to intl service and read it', function(assert) {
     assert.expect(1);
     run(() => {
-        let service = this.container.lookup('service:intl');
+        const service = this.container.lookup('service:intl');
         service.addTranslation('en-us', 'oh', 'hai!').then(() => {
-            view = this.render(hbs`{{format-message (intl-get "oh")}}`, { locale: 'en-us' });
+            view = this.render(hbs`{{format-message (intl-get "oh")}}`, 'en-us');
             runAppend(view);
             assert.equal(view.$().text(), "hai!");
         });
@@ -198,14 +198,14 @@ test('locale can add messages object and intl-get can read it', function(assert)
         'bulk-add': 'bulk add works'
     });
 
-    view = this.render(hbs`{{format-message (intl-get "bulk-add")}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-message (intl-get "bulk-add")}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), "bulk add works");
 });
 
 test('should respect format options for date ICU block', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-message "Sale begins {day, date, shortWeekDay}" day=1390518044403}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-message "Sale begins {day, date, shortWeekDay}" day=1390518044403}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), "Sale begins January 23, 2014");
 });
@@ -223,7 +223,7 @@ test('intl-get returns message for key that is a literal string (not an object p
     translation['string.path.works'] = 'yes it does';
 
     try {
-      view = this.render(hbs`{{format-message (intl-get "string.path.works")}}`, {locale: 'en-us'});
+      view = this.render(hbs`{{format-message (intl-get "string.path.works")}}`, 'en-us');
       runAppend(view);
       assert.equal(view.$().text(), "yes it does");
     } catch(ex) {

--- a/tests/unit/format-number-test.js
+++ b/tests/unit/format-number-test.js
@@ -47,20 +47,20 @@ test('exists', function(assert) {
 test('invoke the formatNumber method', function(assert) {
     assert.expect(1);
     let service = this.container.lookup('service:intl');
-    Ember.run(function() { service.set('locale', 'en-us'); });
+    Ember.run(function() { service.setLocale('en-us'); });
     assert.equal(service.formatNumber(100), 100);
 });
 
 test('number is formatted correctly with default locale', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-number 1000}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-number 1000}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), "1,000");
 });
 
 test('number is formatted correctly with locale argument', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-number 1000}}`, { locale: 'fr-fr' });
+    view = this.render(hbs`{{format-number 1000}}`, 'fr-fr');
     runAppend(view);
     // non-breaking space so we can't just compare "1 000" to "1 000"
     // since it's not a %20 space character
@@ -75,14 +75,14 @@ test('should throw if called with out a value', function(assert) {
 
 test('should return a string', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-number 4}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-number 4}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), '4');
 });
 
 test('should return a decimal as a string', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-number NUM}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-number NUM}}`, 'en-us');
     view.set('context', { NUM: 4.004 });
     runAppend(view);
     assert.equal(view.$().text(), '4.004');
@@ -90,7 +90,7 @@ test('should return a decimal as a string', function(assert) {
 
 test('should return a formatted string with a thousand separator', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-number NUM}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-number NUM}}`, 'en-us');
     view.set('context', { NUM: 40000 });
     runAppend(view);
     assert.equal(view.$().text(), '40,000');
@@ -99,7 +99,7 @@ test('should return a formatted string with a thousand separator', function(asse
 
 test('should return a formatted string with a thousand separator and decimal', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-number NUM}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-number NUM}}`, 'en-us');
     view.set('context', { NUM: 40000.004 });
     runAppend(view);
     assert.equal(view.$().text(), '40,000.004');
@@ -115,14 +115,14 @@ test('locale can be passed as an argument', function(assert) {
 
 test('in another locale - should return a string', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-number 4}}`, { locale: 'de-de' });
+    view = this.render(hbs`{{format-number 4}}`, 'de-de');
     runAppend(view);
     assert.equal(view.$().text(), '4');
 });
 
 test('in another locale - should return a decimal as a string', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-number NUM}}`, { locale: 'de-de' });
+    view = this.render(hbs`{{format-number NUM}}`, 'de-de');
     view.set('context', { NUM: 4.004 });
     runAppend(view);
     assert.equal(view.$().text(), '4,004');
@@ -131,7 +131,7 @@ test('in another locale - should return a decimal as a string', function(assert)
 
 test('in another locale - should return a formatted string with a thousand separator', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-number NUM}}`, { locale: 'de-de' });
+    view = this.render(hbs`{{format-number NUM}}`, 'de-de');
     view.set('context', { NUM: 40000 });
     runAppend(view);
     assert.equal(view.$().text(), '40.000');
@@ -139,7 +139,7 @@ test('in another locale - should return a formatted string with a thousand separ
 
 test('in another locale - should return a formatted string with a thousand separator and decimal', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-number NUM}}`, { locale: 'de-de' });
+    view = this.render(hbs`{{format-number NUM}}`, 'de-de');
     view.set('context', { NUM: 40000.004 });
     runAppend(view);
     assert.equal(view.$().text(), '40.000,004');
@@ -147,13 +147,13 @@ test('in another locale - should return a formatted string with a thousand separ
 
 test('currency - should return a string formatted to currency', function(assert) {
     assert.expect(3);
-    view = this.render(hbs`{{format-number 40000 format="currency" style="currency" currency="USD"}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-number 40000 format="currency" style="currency" currency="USD"}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), '$40,000.00');
-    view = this.render(hbs`{{format-number 40000 format="currency" style="currency" currency="EUR"}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-number 40000 format="currency" style="currency" currency="EUR"}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), '€40,000.00');
-    view = this.render(hbs`{{format-number 40000 style="currency" currency="JPY"}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-number 40000 style="currency" currency="JPY"}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), '¥40,000');
 });
@@ -163,7 +163,7 @@ test('should function within an `each` block helper', function(assert) {
     view = this.render(
       hbs`
         {{#each currencies as |currency|}}{{format-number currency.AMOUNT format="currency" style="currency" currency=currency.CURRENCY}}{{/each}}
-      `, { locale: 'en-us' }
+      `, 'en-us'
     );
 
     view.set('context', {
@@ -180,24 +180,24 @@ test('should function within an `each` block helper', function(assert) {
 
 test('should be able to combine hash options with format options', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-number 1 format="digits" minimumIntegerDigits=10}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-number 1 format="digits" minimumIntegerDigits=10}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), '0,000,000,001.00', 'should return a string formatted to a percent');
 });
 
 test('should be able to combine hash options with format options with dasherized options name', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-number 1 format="digits" minimum-integer-digits=10}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-number 1 format="digits" minimum-integer-digits=10}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), '0,000,000,001.00', 'should return a string formatted to a percent');
 });
 
 test('used to format percentages', function(assert) {
     assert.expect(2);
-    view = this.render(hbs`{{format-number 400 style="percent"}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-number 400 style="percent"}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), '40,000%', 'should return a string formatted to a percent');
-    view = this.render(hbs`{{format-number 400 style="percent"}}`, { locale: 'de-de' });
+    view = this.render(hbs`{{format-number 400 style="percent"}}`, 'de-de');
     runAppend(view);
     assert.equal(escape(view.$().text()), '40.000%A0%25', 'de should return a string formatted to a percent');
 });

--- a/tests/unit/format-relative-test.js
+++ b/tests/unit/format-relative-test.js
@@ -47,7 +47,7 @@ test('exists', function(assert) {
 test('invoke the formatRelative directly', function(assert) {
     assert.expect(1);
     let service = this.container.lookup('service:intl');
-    Ember.run(() => { service.set('locale', 'en-us'); });
+    Ember.run(() => { service.setLocale('en-us'); });
     assert.equal(service.formatRelative(new Date()), 'now', {});
 });
 
@@ -59,14 +59,14 @@ test('should throw if called with out a value', function(assert) {
 
 test('can specify a `value` and `now` on the options hash', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-relative 2000 now=0}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-relative 2000 now=0}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), 'in 2 seconds');
 });
 
 test('should return relative time in hours, not best fit', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-relative date now=0 format="hours"}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-relative date now=0 format="hours"}}`, 'en-us');
     view.set('context', { date: (1000 * 60 * 60 * 24) * 2 }); // two days
     runAppend(view);
     assert.equal(view.$().text(), 'in 48 hours');
@@ -74,7 +74,7 @@ test('should return relative time in hours, not best fit', function(assert) {
 
 test('should return now', function(assert) {
     assert.expect(1);
-    view = this.render(hbs`{{format-relative date}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-relative date}}`, 'en-us');
     view.set('context', { date: new Date().getTime() });
     runAppend(view);
     assert.equal(view.$().text(), 'now');

--- a/tests/unit/format-time-test.js
+++ b/tests/unit/format-time-test.js
@@ -18,7 +18,7 @@ moduleFor('ember-intl@formatter:format-time', {
     needs: ['service:intl'],
     beforeEach() {
         registerHelper('format-time', formatTimeHelper, this.container);
-        this.intlBlock = createIntlBlock(this.container);
+        this.render = createIntlBlock(this.container);
     },
     afterEach() {
         runDestroy(view);
@@ -61,14 +61,14 @@ test('invoke formatTime directly', function(assert) {
 
 test('should throw if called with out a value', function(assert) {
     assert.expect(1);
-    view = this.intlBlock(hbs`{{format-time}}`);
+    view = this.render(hbs`{{format-time}}`);
     assert.throws(runAppend(view), Error, 'raised error when not value is passed to format-time');
 });
 
 test('it should return a formatted string from a date string', function(assert) {
     assert.expect(1);
     // Must provide `timeZone` because: https://github.com/yahoo/ember-intl/issues/21
-    view = this.intlBlock(hbs`{{format-time dateString timeZone='UTC'}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-time dateString timeZone='UTC'}}`, 'en-us');
     view.set('context', { dateString: 'Thu Jan 23 2014 18:00:44 GMT-0500 (EST)' });
     runAppend(view);
     assert.equal(view.$().text(), '1/23/2014');
@@ -77,7 +77,7 @@ test('it should return a formatted string from a date string', function(assert) 
 test('it should return a formatted string from a timestamp', function(assert) {
     assert.expect(1);
     // Must provide `timeZone` because: https://github.com/yahoo/ember-intl/issues/21
-    view = this.intlBlock(hbs`{{format-time date timeZone='UTC'}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-time date timeZone='UTC'}}`, 'en-us');
     view.set('context', { date: date });
     runAppend(view);
     assert.equal(view.$().text(), '1/23/2014');
@@ -85,7 +85,7 @@ test('it should return a formatted string from a timestamp', function(assert) {
 
 test('it should return a formatted string of just the time', function(assert) {
     assert.expect(1);
-    view = this.intlBlock(hbs`{{format-time date hour='numeric' minute='numeric' timeZone='UTC'}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{format-time date hour='numeric' minute='numeric' timeZone='UTC'}}`, 'en-us');
     view.set('context', { date: date });
     runAppend(view);
     assert.equal(view.$().text(), '11:00 PM');
@@ -94,7 +94,7 @@ test('it should return a formatted string of just the time', function(assert) {
 test('it should format the epoch timestamp', function(assert) {
     assert.expect(1);
     let locale = 'en-us';
-    view = this.intlBlock(hbs`{{format-time 0}}`, { locale: locale });
+    view = this.render(hbs`{{format-time 0}}`, locale);
     runAppend(view);
     assert.equal(view.$().text(), new Intl.DateTimeFormat(locale).format(0));
 });

--- a/tests/unit/intl-get-test.js
+++ b/tests/unit/intl-get-test.js
@@ -64,12 +64,12 @@ modernHelperTest('should recompute on intl locale change in >= 1.13.0', function
         }
     });
 
-    view = this.render(hbs`{{intl-get "greeting"}}`, { locale: 'en-us' });
+    view = this.render(hbs`{{intl-get "greeting"}}`, 'en-us');
     runAppend(view);
 
     run(() => {
-        service.set('locale', 'fr-fr');
-        service.set('locale', 'en-us');
+        service.setLocale('fr-fr');
+        service.setLocale('en-us');
         assert.equal(triggered, 2);
     });
 


### PR DESCRIPTION
`exists` is to bring in the i18n API, similar to addTranslation/addTranslations for the eventually converging  of the two projects.

Use `setLocale` instead of `Ember.set` since it's possible for there to be some asynchronous behavior (fetching of translations) and validating that translations exist for the locale before setting.  So the helpers and whatever else is listening for locale changes should really be listening for an event instead, notifying that the locale change is ready.