### PR TITLE
adding `interval` property to format-relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ export default Ember.Component.extend({
   })
 });
 ```
+
+#### Live Relative Timestamp
+A new feature, only available when using >= Ember 1.13, is the ability to recompute the relative timestamp on an interval by passing an `interval` argument (in milliseconds).
+
+```hbs
+{{format-relative now interval=1000}} -> now, 1 second ago, 2 seconds ago, etc. (will recompute every 1s)
+```
+
 #### Format Relative Options
 [List of supported format date options](https://github.com/yahoo/ember-intl/wiki/Format-Relative-Options)
 
@@ -212,7 +220,6 @@ Or programmatically convert a message within any Ember Object.
 export default Ember.Component.extend({
   intl: Ember.inject.service(),
   yesterday: Ember.computed(function() {
-    var now = new Date();
     return this.get('intl').formatMessage('Hello {name}', { name: 'Jason' });
   })
 });

--- a/addon/helpers/format-relative.js
+++ b/addon/helpers/format-relative.js
@@ -3,6 +3,22 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
+import Ember from 'ember';
 import formatHelper from './-base';
 
-export default formatHelper('relative');
+let RelativeHelper = formatHelper('relative');
+
+if (Ember.Helper && Ember.Helper.detect(RelativeHelper)) {
+    const { later:runLater } = Ember.run;
+
+    RelativeHelper = RelativeHelper.extend({
+        compute(value, hash) {
+            if (hash && hash.interval) {
+                runLater(this, this.recompute, parseInt(hash.interval, 10));
+            }
+            return this._super(...arguments);
+        }
+    });
+}
+
+export default RelativeHelper;

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -3,8 +3,8 @@ import computed from 'ember-new-computed';
 
 const { set, Controller, inject, on, run:emberRun } = Ember;
 
-const now       = new Date();
-const yesterday = now.setDate(now.getDate() - 1);
+const date      = new Date();
+const yesterday = date.setDate(date.getDate() - 1);
 
 export default Controller.extend({
     intl:      inject.service(),
@@ -12,7 +12,8 @@ export default Controller.extend({
     num:       1000,
     yesterday: yesterday,
     deadline:  computed.readOnly('yesterday'),
-    now:       now,
+    instant:   new Date(),
+    now:       new Date(),
 
     messages: {
         photos: '{name} took {numPhotos, plural,\n  =0 {no photos}\n  =1 {one photo}\n  other {# photos}\n} on {takenDate, date, long}.\n'
@@ -27,7 +28,7 @@ export default Controller.extend({
     incrementTime: on('init', function() {
         setInterval(() => {
             emberRun(() => {
-                set(this, 'now', new Date());
+                set(this, 'instant', new Date());
                 this.incrementProperty('num');
             });
         }, 200);

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -8,18 +8,23 @@
 {{code-snippet name='format-number.hbs'}}
 
 <h3>Format Date</h3>
-<div>{{format-date now}}</div>
+<div>{{format-date instant}}</div>
 <div>{{format-date yesterday}}</div>
 
 <h3>Format Time</h3>
-<div>{{format-time now format='hhmmss'}}</div>
-<div>{{format-time now hour='numeric' second='numeric' minute='numeric' hour12=false}}</div>
+<div>{{format-time instant format='hhmmss'}}</div>
+<div>{{format-time instant hour='numeric' second='numeric' minute='numeric' hour12=false}}</div>
 
 {{code-snippet name='format-time.hbs'}}
 
 <h3>Format Relative</h3>
 <div>{{format-relative yesterday}}</div>
-<div>{{format-relative now}}</div>
+<div>{{format-relative instant}}</div>
+<div>{{format-relative now interval=1000}}</div>
+
+<div>
+    {{code-snippet name='format-relative.hbs'}}
+</div>
 
 <h3>Format Message</h3>
 

--- a/tests/dummy/snippets/format-relative.hbs
+++ b/tests/dummy/snippets/format-relative.hbs
@@ -1,0 +1,3 @@
+{{format-relative yesterday}}
+{{format-relative instant}}
+{{format-relative now interval=1000}}

--- a/tests/unit/format-relative-test.js
+++ b/tests/unit/format-relative-test.js
@@ -10,6 +10,7 @@ import formatRelativehelper from 'ember-intl/helpers/format-relative';
 import registerHelper from 'ember-intl/utils/register-helper';
 import { runAppend, runDestroy } from '../helpers/run-append';
 import createIntlBlock from '../helpers/create-intl-block';
+import modernHelperTest from '../helpers/test';
 
 const { run:emberRun } = Ember;
 
@@ -64,6 +65,19 @@ test('can specify a `value` and `now` on the options hash', function(assert) {
     view = this.render(hbs`{{format-relative 2000 now=0}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().text(), 'in 2 seconds');
+});
+
+modernHelperTest('can specify a `interval` to trigger recompute', function(assert) {
+    assert.expect(2);
+    view = this.render(hbs`{{format-relative date interval=1000}}`, 'en-us');
+    view.set('context', { date: new Date() });
+    runAppend(view);
+    assert.equal(view.$().text(), 'now');
+    stop();
+    setTimeout(() => {
+        start();
+        assert.equal(view.$().text(), '1 second ago');
+    }, 1001);
 });
 
 test('should return relative time in hours, not best fit', function(assert) {


### PR DESCRIPTION
`{{format-relative currentDate interval=1000}}`

Renders:
now, 1 second ago, 2 seconds ago, etc. (will recompute every 1s)

Disabled by default, only possible on >= Ember 1.13