### PR TITLE
Fixed initializers for Ember 2.0 (including beta/canary)

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -103,6 +103,8 @@ const IntlService = Service.extend(Evented, {
 
         if (instance.registry) {
             container = instance.registry;
+        } else if (container.registry && container.registry.register) {
+            container = container.registry;
         }
 
         if (container.has(name)) {

--- a/lib/utils/is-modern.js
+++ b/lib/utils/is-modern.js
@@ -8,7 +8,7 @@
 function isModern(instance) {
     var checker = new VersionChecker(instance);
     var dep     = checker.for('ember', 'bower');
-    return dep.satisfies('>= 1.13.0');
+    return dep.satisfies('>= 1.13.0 || >= 2.0.0-0');
 }
 
 module.exports = isModern;


### PR DESCRIPTION
Fixes the `is-modern` ember-cli util to include Ember 2.0 versions (including pre-release), so that the initializers and instance-initializers are correct.

Also fixes the registry lookup in the `createLocale()` function in the `intl` service.