### PR TITLE
[BUGFIX] Funnel#files is meant to be a fully expanded list of files, …

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = {
         // with the native Intl API
         trees.push(new Funnel(intlPath + '/locale-data/jsonp', {
             srcDir:  '/',
-            files:   ['*.js'],
+            includes:   ['*.js'],
             destDir: '/assets/intl/polyfill/locales/'
         }));
 


### PR DESCRIPTION
…not a glob

Funnel#includes can be used for globs.

This is meant as a 1.3.x release, which means it will never apply cleanly to master. We should likely create 1.3.x-stable branch, to PR against.