### PR TITLE
Fixed initializer for ember-canary

### DIFF
--- a/lib/utils/is-modern.js
+++ b/lib/utils/is-modern.js
@@ -8,7 +8,7 @@
 function isModern(instance) {
     var checker = new VersionChecker(instance);
     var dep     = checker.for('ember', 'bower');
-    return dep.satisfies('>= 1.13.0 || >= 2.0.0-0');
+    return dep.satisfies('>= 1.13.0 || >= 2.0.0-0 || >= 2.1.0-0 || >= 2.2.0-0');
 }
 
 module.exports = isModern;


### PR DESCRIPTION
Ember canary minor version has been bumped (2.0.0-x to 2.1.0-beta and 2.2.0-canary), which has broken the ember-intl instance initializer again. Updating the semver `satisfies` string fixes it.

Do we need to think of a way to change `is-modern.js` to support future version bumps of ember-canary?