### PR TITLE
add formatHtmlMessage to the intl service

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -41,6 +41,7 @@ const IntlService = Service.extend(Evented, {
 
     formatRelative: formatterProxy('relative'),
     formatMessage : formatterProxy('message'),
+    formatHtmlMessage : formatterProxy('html-message'),
     formatNumber  : formatterProxy('number'),
     formatTime    : formatterProxy('time'),
     formatDate    : formatterProxy('date'),

--- a/tests/unit/format-html-message-test.js
+++ b/tests/unit/format-html-message-test.js
@@ -30,6 +30,13 @@ test('exists', function(assert) {
     assert.ok(formatHtmlHelper);
 });
 
+test('invoke the formatHTMLMessage directly', function(assert) {
+    assert.expect(1);
+    const service = this.container.lookup('service:intl');
+    assert.equal(service.formatHtmlMessage("<strong>Hello {name}</strong>", { name: "<em>Jason</em>" }),
+                 "<strong>Hello &lt;em&gt;Jason&lt;/em&gt;</strong>");
+});
+
 test('message is formatted correctly with argument', function(assert) {
     assert.expect(1);
     view = this.render(hbs`{{format-html-message "Hello {name}" name="Jason"}}`, 'en-us');


### PR DESCRIPTION
Adds `formatHtmlMessage` to the `intl` service. Not sure if there's a reason this formatter has been excluded until now, but if not, here's a simple PR that'll bring it into the fold.