### PR TITLE
adding format-message id attr

### DIFF
--- a/addon/helpers/-base-legacy.js
+++ b/addon/helpers/-base-legacy.js
@@ -17,7 +17,7 @@ const { get } = Ember;
 
 function helperFactory(formatType) {
     function throwError() {
-        return new Error(`${formatType} requires a single unname argument. {{format-${formatType} value}}`);
+        throw new Error(`${formatType} requires a single unname argument. {{format-${formatType} value}}`);
     }
 
     return function (params, hash, seenHash, env) {

--- a/addon/helpers/-base-legacy.js
+++ b/addon/helpers/-base-legacy.js
@@ -15,8 +15,8 @@ import {
 
 const { get } = Ember;
 
-const helperFactory = function (formatType) {
-    function throwError () {
+function helperFactory(formatType) {
+    function throwError() {
         return new Error(`${formatType} requires a single unname argument. {{format-${formatType} value}}`);
     }
 
@@ -84,6 +84,6 @@ const helperFactory = function (formatType) {
 
         return outStream;
     };
-};
+}
 
 export default helperFactory;

--- a/addon/helpers/-base-legacy.js
+++ b/addon/helpers/-base-legacy.js
@@ -20,15 +20,14 @@ function getValue(params) {
 }
 
 function helperFactory(formatType, optionalGetValue = getValue) {
-    return function (params, hash, seenHash, env) {
+    return function (params, hash, options, env) {
         let outStream;
 
         function touchStream() {
             outStream.notify();
         }
 
-        seenHash = readHash(hash);
-
+        const seenHash = readHash(hash);
         const view = env.data.view;
         const intl = view.container.lookup('service:intl');
         const formatter = view.container.lookup(`ember-intl@formatter:format-${formatType}`);

--- a/addon/helpers/-base-legacy.js
+++ b/addon/helpers/-base-legacy.js
@@ -20,7 +20,7 @@ function getValue(params) {
 }
 
 function helperFactory(formatType, optionalGetValue = getValue) {
-    return function (params, hash, options, env) {
+    return function legacyIntlHelper(params, hash, options, env) {
         let outStream;
 
         function touchStream() {
@@ -47,7 +47,7 @@ function helperFactory(formatType, optionalGetValue = getValue) {
             let format = {};
 
             if (seenHash && seenHash.format) {
-                format = intl.getFormat(formatType, seenHash.format) || {};
+                format = intl.getFormat(formatType, seenHash.format);
             }
 
             return formatter.format.call(

--- a/addon/helpers/-base-legacy.js
+++ b/addon/helpers/-base-legacy.js
@@ -15,19 +15,15 @@ import {
 
 const { get } = Ember;
 
-function helperFactory(formatType) {
-    function throwError() {
-        throw new Error(`${formatType} requires a single unname argument. {{format-${formatType} value}}`);
-    }
+function getValue(params) {
+    return params[0];
+}
 
+function helperFactory(formatType, optionalGetValue = getValue) {
     return function (params, hash, seenHash, env) {
-        if (!params || !params.length) {
-            return throwError();
-        }
-
         let outStream;
 
-        function touchStream () {
+        function touchStream() {
             outStream.notify();
         }
 
@@ -36,7 +32,11 @@ function helperFactory(formatType) {
         const view = env.data.view;
         const intl = view.container.lookup('service:intl');
         const formatter = view.container.lookup(`ember-intl@formatter:format-${formatType}`);
-        const value = params[0];
+        const value = optionalGetValue(params, hash, intl);
+
+        if (typeof value === 'undefined') {
+            throw new Error(`format-${formatType} helper requires value`);
+        }
 
         if (value.isStream) {
             value.subscribe(() => {

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -44,7 +44,7 @@ function helperFactory(formatType, optionalGetValue) {
             let format = {};
 
             if (hash.format) {
-                format = intl.getFormat(formatType, hash.format) || {};
+                format = intl.getFormat(formatType, hash.format);
             }
 
             return formatter.format(

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -9,14 +9,17 @@ import computed from 'ember-new-computed';
 
 const { Helper, inject, get } = Ember;
 
-function helperFactory(formatType) {
+function getValue(params) {
+    return params[0];
+}
+
+function helperFactory(formatType, optionalGetValue) {
     return Helper.extend({
         intl: inject.service(),
         formatType: formatType,
 
         formatter: computed('formatType', {
             get() {
-                const formatType = get(this, 'formatType');
                 return this.container.lookup(`ember-intl@formatter:format-${formatType}`);
             }
         }),
@@ -27,17 +30,15 @@ function helperFactory(formatType) {
             intl.on('localeChanged', this, this.recompute);
         },
 
-        getValue(params) {
-            return params[0];
-        },
+        getValue: optionalGetValue || getValue,
 
         compute(params, hash) {
             const intl = get(this, 'intl');
             const formatter = get(this, 'formatter');
-            const value = this.getValue(params, hash);
+            const value = this.getValue(params, hash, intl);
 
             if (typeof value === 'undefined') {
-                throw new Error(`${formatType} requires a single unname argument. {{format-${formatType} value}}`);
+                throw new Error(`format-${formatType} helper requires value`);
             }
 
             let format = {};

--- a/addon/helpers/format-date.js
+++ b/addon/helpers/format-date.js
@@ -3,6 +3,6 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import formatHelper from './-base';
+import helperFactory from './-base';
 
-export default formatHelper('date');
+export default helperFactory('date');

--- a/addon/helpers/format-html-message.js
+++ b/addon/helpers/format-html-message.js
@@ -3,6 +3,18 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import formatHelper from './-base';
+import Ember from 'ember';
+import factory from './-base';
+import { getValue } from './format-message';
 
-export default formatHelper('html-message');
+const { Helper } = Ember;
+
+let HtmlMessageHelper = factory('html-message');
+
+if (Helper && Helper.detect(HtmlMessageHelper)) {
+    HtmlMessageHelper = HtmlMessageHelper.extend({
+        getValue: getValue
+    });
+}
+
+export default HtmlMessageHelper;

--- a/addon/helpers/format-html-message.js
+++ b/addon/helpers/format-html-message.js
@@ -3,18 +3,7 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import Ember from 'ember';
-import factory from './-base';
+import helperFactory from './-base';
 import { getValue } from './format-message';
 
-const { Helper } = Ember;
-
-let HtmlMessageHelper = factory('html-message');
-
-if (Helper && Helper.detect(HtmlMessageHelper)) {
-    HtmlMessageHelper = HtmlMessageHelper.extend({
-        getValue: getValue
-    });
-}
-
-export default HtmlMessageHelper;
+export default helperFactory('html-message', getValue);

--- a/addon/helpers/format-message.js
+++ b/addon/helpers/format-message.js
@@ -3,28 +3,16 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import Ember from 'ember';
 import helperFactory from './-base';
 
-const { Helper, get } = Ember;
-
-let MessageHelper = helperFactory('message');
-
-export function getValue(params, hash) {
+export function getValue(params, hash, intl) {
     if (params.length) {
         return params[0];
     }
 
     if (hash && hash.hasOwnProperty('id')) {
-        const intl = get(this, 'intl');
         return intl.findTranslationByKey(hash.id, hash.locale);
     }
 }
 
-if (Helper && Helper.detect(MessageHelper)) {
-    MessageHelper = MessageHelper.extend({
-        getValue: getValue
-    });
-}
-
-export default MessageHelper;
+export default helperFactory('message', getValue);

--- a/addon/helpers/format-message.js
+++ b/addon/helpers/format-message.js
@@ -3,6 +3,28 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import formatHelper from './-base';
+import Ember from 'ember';
+import helperFactory from './-base';
 
-export default formatHelper('message');
+const { Helper, get } = Ember;
+
+let MessageHelper = helperFactory('message');
+
+export function getValue(params, hash) {
+    if (params.length) {
+        return params[0];
+    }
+
+    if (hash && hash.hasOwnProperty('id')) {
+        const intl = get(this, 'intl');
+        return intl.findTranslationByKey(hash.id, hash.locale);
+    }
+}
+
+if (Helper && Helper.detect(MessageHelper)) {
+    MessageHelper = MessageHelper.extend({
+        getValue: getValue
+    });
+}
+
+export default MessageHelper;

--- a/addon/helpers/format-number.js
+++ b/addon/helpers/format-number.js
@@ -3,6 +3,6 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import formatHelper from './-base';
+import helperFactory from './-base';
 
-export default formatHelper('number');
+export default helperFactory('number');

--- a/addon/helpers/format-relative.js
+++ b/addon/helpers/format-relative.js
@@ -4,11 +4,13 @@
  */
 
 import Ember from 'ember';
-import formatHelper from './-base';
+import helperFactory from './-base';
 
-let RelativeHelper = formatHelper('relative');
+const { Helper } = Ember;
 
-if (Ember.Helper && Ember.Helper.detect(RelativeHelper)) {
+let RelativeHelper = helperFactory('relative');
+
+if (Helper && Helper.detect(RelativeHelper)) {
     const runBind = Ember.run.bind;
 
     RelativeHelper = RelativeHelper.extend({

--- a/addon/helpers/format-time.js
+++ b/addon/helpers/format-time.js
@@ -3,6 +3,6 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-import formatHelper from './-base';
+import helperFactory from './-base';
 
-export default formatHelper('time');
+export default helperFactory('time');

--- a/addon/helpers/intl-get.js
+++ b/addon/helpers/intl-get.js
@@ -5,13 +5,13 @@
 
 import Ember from 'ember';
 
-const { get } = Ember;
+const { Helper, inject, get } = Ember;
 
-let Helper = null;
+let IntlGetHelper = null;
 
-if (Ember.Helper) {
-    Helper = Ember.Helper.extend({
-        intl: Ember.inject.service(),
+if (Helper) {
+    IntlGetHelper = Helper.extend({
+        intl: inject.service(),
 
         init() {
             this._super(...arguments);
@@ -33,4 +33,4 @@ if (Ember.Helper) {
 }
 
 
-export default Helper;
+export default IntlGetHelper;

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -15,8 +15,7 @@ function formatterProxy (formatType) {
         const formatter = this.container.lookup(`ember-intl@formatter:format-${formatType}`);
 
         if (typeof options.format === 'string') {
-            const format = this.getFormat(formatType, options.format);
-            options = extend(format, options);
+            options = extend(this.getFormat(formatType, options.format), options);
         }
 
         if (!options.locale) {
@@ -121,6 +120,8 @@ const IntlService = Service.extend(Evented, {
         if (formats && formatType && typeof format === 'string') {
             return get(formats, `${formatType}.${format}`);
         }
+
+        return {};
     },
 
     translationsFor(locale) {

--- a/tests/unit/format-date-test.js
+++ b/tests/unit/format-date-test.js
@@ -45,7 +45,11 @@ test('invoke the formatDate directly', function(assert) {
 test('should throw if called with out a value', function(assert) {
     assert.expect(1);
     view = this.render(hbs`{{format-date}}`);
-    assert.throws(runAppend(view), Error, 'raised error when not value is passed to format-date');
+    try {
+        runAppend(view);
+    } catch(ex) {
+        assert.ok(ex, 'raised error when not value is passed to format-date');
+    }
 });
 
 test('it should return a formatted string from a date string', function(assert) {

--- a/tests/unit/format-html-message-test.js
+++ b/tests/unit/format-html-message-test.js
@@ -7,18 +7,28 @@ import hbs from 'htmlbars-inline-precompile';
 import { moduleFor, test } from 'ember-qunit';
 import formatHtmlHelper from 'ember-intl/helpers/format-html-message';
 import registerHelper from 'ember-intl/utils/register-helper';
+import Translation from 'ember-intl/models/translation';
 
 import { runAppend, runDestroy } from '../helpers/run-append';
 import createIntlBlock from '../helpers/create-intl-block';
+import intlGet from '../../helpers/intl-get';
 
 let view, registry;
 
 moduleFor('ember-intl@formatter:format-html-message', {
-    needs: ['service:intl'],
+    needs: ['service:intl', 'ember-intl@adapter:-intl-adapter'],
     beforeEach() {
         registry = this.registry || this.container;
         registerHelper('format-html-message', formatHtmlHelper, registry);
+        registry.register('helper:intl-get', intlGet);
         registry.injection('formatter', 'intl', 'service:intl');
+        registry.register('ember-intl@translation:en-us', Translation.extend({
+            foo: {
+                bar: 'foo bar baz',
+                baz: 'baz baz baz'
+            }
+        }));
+
         this.render = createIntlBlock(registry);
     },
     afterEach() {
@@ -48,7 +58,11 @@ test('message is formatted correctly with argument', function(assert) {
 test('should throw if called with out a value', function(assert) {
     assert.expect(1);
     view = this.render(hbs`{{format-html-message}}`);
-    assert.throws(runAppend(view), Error, 'raised error when not value is passed to format-html-message', 'en-us');
+    try {
+        runAppend(view);
+    } catch(ex) {
+        assert.ok(ex, 'raised error when not value is passed to format-html-message');
+    }
 });
 
 test('should allow for inlined html in the value', function(assert) {
@@ -70,4 +84,11 @@ test('should allow for inlined html in the value but escape arguments', function
     view = this.render(hbs`{{format-html-message "<strong>Hello {name}</strong>" name="<em>Jason</em>"}}`, 'en-us');
     runAppend(view);
     assert.equal(view.$().html(), "<strong>Hello &lt;em&gt;Jason&lt;/em&gt;</strong>");
+});
+
+test('can look up translations by id/key', function(assert) {
+    assert.expect(1);
+    view = this.render(hbs`{{format-html-message id="foo.bar"}}`, 'en-us');
+    runAppend(view);
+    assert.equal(view.$().text(), "foo bar baz");
 });

--- a/tests/unit/format-message-test.js
+++ b/tests/unit/format-message-test.js
@@ -75,7 +75,11 @@ test('message is formatted correctly with argument', function(assert) {
 test('should throw if called with out a value', function(assert) {
     assert.expect(1);
     view = this.render(hbs`{{format-message}}`, 'en-us');
-    assert.throws(runAppend(view), Error, 'raised error when not value is passed to format-message');
+    try {
+        runAppend(view);
+    } catch(ex) {
+        assert.ok(ex, 'raised error when not value is passed to format-message');
+    }
 });
 
 test('should return a formatted string', function(assert) {
@@ -138,6 +142,13 @@ test('should return a formatted string with an `each` block', function(assert) {
 
     runAppend(view);
     assert.equal(view.$().text().trim(), "Allison harvested 10 apples.Jeremy harvested 60 apples.");
+});
+
+test('can look up translations by id/key', function(assert) {
+    assert.expect(1);
+    view = this.render(hbs`{{format-message id="foo.bar"}}`, 'en-us');
+    runAppend(view);
+    assert.equal(view.$().text(), "foo bar baz");
 });
 
 test('intl-get returns message and format-message renders', function(assert) {

--- a/tests/unit/format-number-test.js
+++ b/tests/unit/format-number-test.js
@@ -72,7 +72,11 @@ test('number is formatted correctly with locale argument', function(assert) {
 test('should throw if called with out a value', function(assert) {
     assert.expect(1);
     view = this.render(hbs`{{format-number}}`);
-    assert.throws(runAppend(view), Error, 'raised error when not value is passed to format-number');
+    try {
+        runAppend(view);
+    } catch(ex) {
+        assert.ok(ex, 'raised error when not value is passed to format-number');
+    }
 });
 
 test('should return a string', function(assert) {

--- a/tests/unit/format-relative-test.js
+++ b/tests/unit/format-relative-test.js
@@ -58,7 +58,11 @@ test('invoke the formatRelative directly', function(assert) {
 test('should throw if called with out a value', function(assert) {
     assert.expect(1);
     view = this.render(hbs`{{format-relative}}`);
-    assert.throws(runAppend(view), Error, 'raised error when not value is passed to format-relative');
+    try {
+        runAppend(view);
+    } catch(ex) {
+        assert.ok(ex, 'raised error when not value is passed to format-relative');
+    }
 });
 
 test('can specify a `value` and `now` on the options hash', function(assert) {

--- a/tests/unit/format-time-test.js
+++ b/tests/unit/format-time-test.js
@@ -62,7 +62,11 @@ test('invoke formatTime directly', function(assert) {
 test('should throw if called with out a value', function(assert) {
     assert.expect(1);
     view = this.render(hbs`{{format-time}}`);
-    assert.throws(runAppend(view), Error, 'raised error when not value is passed to format-time');
+    try {
+        runAppend(view);
+    } catch(ex) {
+        assert.ok(ex, 'raised error when not value is passed to format-time');
+    }
 });
 
 test('it should return a formatted string from a date string', function(assert) {


### PR DESCRIPTION
#208 

* [ ] Document
* [x] Test
* [ ] Clean up/rewrite legacy helper
* [x] Add support for the < 1.13 helpers

Enables:
`{{format-message id='foo.bar'}}`
`{{format-message (intl-get 'foo.bar')}}` is still supported