### PR TITLE
allowEmpty

### DIFF
--- a/addon/formatters/-base.js
+++ b/addon/formatters/-base.js
@@ -6,10 +6,15 @@
 import Ember from 'ember';
 import arrayToHash from '../utils/array-to-hash';
 
-const get = Ember.get;
-const camelize = Ember.String.camelize;
+const {
+    get,
+    String:emberString,
+    Object:EmberObject
+} = Ember;
 
-const FormatBase = Ember.Object.extend({
+const { camelize } = emberString;
+
+const FormatBase = EmberObject.extend({
     init() {
         this._super(...arguments);
         this.options = arrayToHash(this.constructor.supportedOptions);
@@ -24,9 +29,9 @@ const FormatBase = Ember.Object.extend({
     * @private
     */
     filterSupporedOptions(input = {}) {
-        let camelizedKey = null;
-        let foundMatch   = false;
-        const out = {};
+        let camelizedKey;
+        let foundMatch = false;
+        let out = {};
 
         for (let key in input) {
             camelizedKey = camelize(key);
@@ -51,7 +56,7 @@ const FormatBase = Ember.Object.extend({
     * @private
     */
     _format(value, formatterOptions = {}, formatOptions = {}) {
-        const formatter  = get(this, 'formatter');
+        const formatter = get(this, 'formatter');
         const { locale } = formatterOptions;
 
         if (!locale) {
@@ -65,7 +70,7 @@ const FormatBase = Ember.Object.extend({
 });
 
 FormatBase.reopenClass({
-    supportedOptions: ['locale', 'format', 'allowEmpty'],
+    supportedOptions: ['locale', 'format'],
     concatenatedProperties: ['supportedOptions']
 });
 

--- a/addon/formatters/-base.js
+++ b/addon/formatters/-base.js
@@ -65,7 +65,7 @@ const FormatBase = Ember.Object.extend({
 });
 
 FormatBase.reopenClass({
-    supportedOptions: ['locale', 'format'],
+    supportedOptions: ['locale', 'format', 'allowEmpty'],
     concatenatedProperties: ['supportedOptions']
 });
 

--- a/addon/formatters/format-date.js
+++ b/addon/formatters/format-date.js
@@ -30,9 +30,7 @@ const FormatDate = Formatter.extend({
         if(value || filteredOpts.allowEmpty === false){
           return this._format(value, filteredOpts);
         }
-        else{
-          return '';
-        }
+        return '';
     }
 });
 

--- a/addon/formatters/format-date.js
+++ b/addon/formatters/format-date.js
@@ -24,13 +24,18 @@ const FormatDate = Formatter.extend({
     }),
 
     format(value, options) {
-        value = value == null || value === '' ? null : new Date(value);
-        assertIsDate(value, 'A date or timestamp must be provided to format-date');
-        var filteredOpts = this.filterSupporedOptions(options);
-        if(value || filteredOpts.allowEmpty === false){
-          return this._format(value, filteredOpts);
+        // reading a stream where the value is null returns
+        // undefined.  so, we need to work around this by setting it
+        // to null.  this condition below can go away once we drop < 1.13 support
+        if (typeof value === 'undefined') {
+            value = null;
         }
-        return '';
+
+        let dateTime = new Date(value);
+        assertIsDate(dateTime, 'A date or timestamp must be provided to format-date');
+        let formatOptions = this.filterSupporedOptions(options);
+
+        return this._format(dateTime, formatOptions);
     }
 });
 

--- a/addon/formatters/format-date.js
+++ b/addon/formatters/format-date.js
@@ -24,9 +24,15 @@ const FormatDate = Formatter.extend({
     }),
 
     format(value, options) {
-        value = new Date(value);
+        value = value == null ? null : new Date(value);
         assertIsDate(value, 'A date or timestamp must be provided to format-date');
-        return this._format(value, this.filterSupporedOptions(options));
+        var filteredOpts = this.filterSupporedOptions(options);
+        if(value || filteredOpts.allowEmpty === false){
+          return this._format(value, filteredOpts);
+        }
+        else{
+          return '';
+        }
     }
 });
 

--- a/addon/formatters/format-date.js
+++ b/addon/formatters/format-date.js
@@ -24,7 +24,7 @@ const FormatDate = Formatter.extend({
     }),
 
     format(value, options) {
-        value = value == null ? null : new Date(value);
+        value = value == null || value === '' ? null : new Date(value);
         assertIsDate(value, 'A date or timestamp must be provided to format-date');
         var filteredOpts = this.filterSupporedOptions(options);
         if(value || filteredOpts.allowEmpty === false){

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -13,7 +13,7 @@ function getValue(params) {
     return params[0];
 }
 
-function helperFactory(formatType, optionalGetValue) {
+function helperFactory(formatType, optionalGetValue, optionalReturnEmpty) {
     return Helper.extend({
         intl: inject.service(),
         formatType: formatType,
@@ -26,16 +26,20 @@ function helperFactory(formatType, optionalGetValue) {
 
         init() {
             this._super(...arguments);
-            const intl = get(this, 'intl');
+            let intl = get(this, 'intl');
             intl.on('localeChanged', this, this.recompute);
         },
 
         getValue: optionalGetValue || getValue,
 
         compute(params, hash) {
-            const intl = get(this, 'intl');
-            const formatter = get(this, 'formatter');
-            const value = this.getValue(params, hash, intl);
+            let intl = get(this, 'intl');
+            let formatter = get(this, 'formatter');
+            let value = this.getValue(params, hash, intl);
+
+            if (optionalReturnEmpty && optionalReturnEmpty(value, hash)) {
+                return;
+            }
 
             if (typeof value === 'undefined') {
                 throw new Error(`format-${formatType} helper requires value`);

--- a/addon/helpers/format-date.js
+++ b/addon/helpers/format-date.js
@@ -3,6 +3,17 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
+import Ember from 'ember';
 import helperFactory from './-base';
 
-export default helperFactory('date');
+export function shouldReturnEmptyString(value, hash) {
+    if (Ember.isEmpty(value)) {
+        if (!hash.hasOwnProperty('allowEmpty') || hash.allowEmpty) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export default helperFactory('date', null, shouldReturnEmptyString);

--- a/addon/helpers/format-time.js
+++ b/addon/helpers/format-time.js
@@ -4,5 +4,6 @@
  */
 
 import helperFactory from './-base';
+import { shouldReturnEmptyString } from './format-date';
 
-export default helperFactory('time');
+export default helperFactory('time', null, shouldReturnEmptyString);

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function generateOptions(app) {
         locales: undefined,
         disablePolyfill: false,
         defaultLocale: 'en-us',
+        allowEmpty: true,
         inputPath: 'translations',
         outputPath: 'translations'
     }, addonConfig);

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,6 +16,7 @@ module.exports = function(environment) {
             locales: ['en-us', 'es-es', 'fr-fr', 'de-de'],
             defaultLocale: 'en-us',
             disablePolyfill: false,
+            allowEmpty: true,
             outputPath: 'translations',
             inputPath: 'tests/dummy/translations'
         }

--- a/tests/unit/format-date-test.js
+++ b/tests/unit/format-date-test.js
@@ -52,6 +52,20 @@ test('should throw if called with out a value', function(assert) {
     }
 });
 
+test('should render empty string for a null value', function(assert) {
+  assert.expect(1);
+  view = this.render(hbs`{{format-date null}}`, defaultLocale);
+  runAppend(view);
+  assert.equal(view.$().text(), '');
+});
+
+test('should render epoch date for a null value when allow empty is false', function(assert) {
+  assert.expect(1);
+  view = this.render(hbs`{{format-date null allowEmpty=false}}`, defaultLocale);
+  runAppend(view);
+  assert.equal(view.$().text(), '12/31/1969');
+});
+
 test('it should return a formatted string from a date string', function(assert) {
     assert.expect(1);
     // Must provide `timeZone` because: https://github.com/yahoo/ember-intl/issues/21

--- a/tests/unit/format-date-test.js
+++ b/tests/unit/format-date-test.js
@@ -59,6 +59,20 @@ test('should render empty string for a null value', function(assert) {
   assert.equal(view.$().text(), '');
 });
 
+test('should render empty string for an empty string value', function(assert) {
+  assert.expect(1);
+  view = this.render(hbs`{{format-date ''}}`, defaultLocale);
+  runAppend(view);
+  assert.equal(view.$().text(), '');
+});
+
+test('should render empty string for an undefined value', function(assert) {
+  assert.expect(1);
+  view = this.render(hbs`{{format-date undefined}}`, defaultLocale);
+  runAppend(view);
+  assert.equal(view.$().text(), '');
+});
+
 test('should render epoch date for a null value when allow empty is false', function(assert) {
   assert.expect(1);
   view = this.render(hbs`{{format-date null allowEmpty=false}}`, defaultLocale);

--- a/tests/unit/format-date-test.js
+++ b/tests/unit/format-date-test.js
@@ -63,7 +63,7 @@ test('should render epoch date for a null value when allow empty is false', func
   assert.expect(1);
   view = this.render(hbs`{{format-date null allowEmpty=false}}`, defaultLocale);
   runAppend(view);
-  assert.equal(view.$().text(), '12/31/1969');
+  assert.equal(view.$().text(), new Intl.DateTimeFormat(defaultLocale).format(0));
 });
 
 test('it should return a formatted string from a date string', function(assert) {

--- a/tests/unit/format-date-test.js
+++ b/tests/unit/format-date-test.js
@@ -42,42 +42,32 @@ test('invoke the formatDate directly', function(assert) {
     }), '1/23/2014');
 });
 
-test('should throw if called with out a value', function(assert) {
-    assert.expect(1);
-    view = this.render(hbs`{{format-date}}`);
-    try {
-        runAppend(view);
-    } catch(ex) {
-        assert.ok(ex, 'raised error when not value is passed to format-date');
-    }
-});
-
 test('should render empty string for a null value', function(assert) {
-  assert.expect(1);
-  view = this.render(hbs`{{format-date null}}`, defaultLocale);
-  runAppend(view);
-  assert.equal(view.$().text(), '');
+    assert.expect(1);
+    view = this.render(hbs`{{format-date null}}`, defaultLocale);
+    runAppend(view);
+    assert.equal(view.$().text(), '');
 });
 
 test('should render empty string for an empty string value', function(assert) {
-  assert.expect(1);
-  view = this.render(hbs`{{format-date ''}}`, defaultLocale);
-  runAppend(view);
-  assert.equal(view.$().text(), '');
+    assert.expect(1);
+    view = this.render(hbs`{{format-date ''}}`, defaultLocale);
+    runAppend(view);
+    assert.equal(view.$().text(), '');
 });
 
 test('should render empty string for an undefined value', function(assert) {
-  assert.expect(1);
-  view = this.render(hbs`{{format-date undefined}}`, defaultLocale);
-  runAppend(view);
-  assert.equal(view.$().text(), '');
+    assert.expect(1);
+    view = this.render(hbs`{{format-date undefined}}`, defaultLocale);
+    runAppend(view);
+    assert.equal(view.$().text(), '');
 });
 
 test('should render epoch date for a null value when allow empty is false', function(assert) {
-  assert.expect(1);
-  view = this.render(hbs`{{format-date null allowEmpty=false}}`, defaultLocale);
-  runAppend(view);
-  assert.equal(view.$().text(), new Intl.DateTimeFormat(defaultLocale).format(0));
+    assert.expect(1);
+    view = this.render(hbs`{{format-date null allowEmpty=false}}`, defaultLocale);
+    runAppend(view);
+    assert.equal(view.$().text(), new Intl.DateTimeFormat(defaultLocale).format(0));
 });
 
 test('it should return a formatted string from a date string', function(assert) {

--- a/tests/unit/format-time-test.js
+++ b/tests/unit/format-time-test.js
@@ -59,16 +59,6 @@ test('invoke formatTime directly', function(assert) {
     }), '23/1/2014');
 });
 
-test('should throw if called with out a value', function(assert) {
-    assert.expect(1);
-    view = this.render(hbs`{{format-time}}`);
-    try {
-        runAppend(view);
-    } catch(ex) {
-        assert.ok(ex, 'raised error when not value is passed to format-time');
-    }
-});
-
 test('it should return a formatted string from a date string', function(assert) {
     assert.expect(1);
     // Must provide `timeZone` because: https://github.com/yahoo/ember-intl/issues/21


### PR DESCRIPTION
This all becomes much nicer once we drop 1.13 support, but for now we live in a world where we need to support two helper formats.

Big thanks to @adamacus for the spike & proposal.