### PR TITLE
Pass formats through to formatter in intl service

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -11,7 +11,7 @@ import Translation from '../models/translation';
 const { assert, get, set, RSVP, Service, Evented, Logger:logger } = Ember;
 
 function formatterProxy (formatType) {
-  return function (value, options = {}) {
+  return function (value, options = {}, formats = null) {
     const formatter = this.container.lookup(`ember-intl@formatter:format-${formatType}`);
 
     if (typeof options.format === 'string') {
@@ -22,7 +22,11 @@ function formatterProxy (formatType) {
       options.locale = get(this, '_locale');
     }
 
-    return formatter.format(value, options);
+    if (!formats) {
+      formats = get(this, 'formats');
+    }
+
+    return formatter.format(value, options, formats);
   };
 }
 

--- a/tests/unit/format-message-test.js
+++ b/tests/unit/format-message-test.js
@@ -65,6 +65,15 @@ test('invoke formatMessage directly', function(assert) {
   }), 'hello world');
 });
 
+test('invoke formatMessage directly with formats', function(assert) {
+  assert.expect(1);
+  const service = this.container.lookup('service:intl');
+  assert.equal(service.formatMessage("Sale begins {day, date, shortWeekDay}", {
+    day: 1390518044403,
+    locale: 'en-us'
+  }), "Sale begins January 23, 2014");
+});
+
 test('message is formatted correctly with argument', function(assert) {
   assert.expect(1);
   view = this.render(hbs`{{format-message "Hello {name}" name="Jason"}}`, 'en-us');


### PR DESCRIPTION
The message formatter takes [3 arguments - `value`, `options` and `formats`](https://github.com/yahoo/ember-intl/blob/a3600ac0dc79aa73977d0a33c5d97fdee6d0dd9b/addon/formatters/format-message.js#L21)

The `formatMessage` method on the service [only passes through `value` and `options`](https://github.com/yahoo/ember-intl/blob/a3600ac0dc79aa73977d0a33c5d97fdee6d0dd9b/addon/services/intl.js#L25) which means you can't format dates/times etc when using the service.

This PR passes through all three arguments, defaulting the formats if not specified.