### PR TITLE
Exists return bool

### DIFF
--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -83,7 +83,7 @@ const IntlService = Service.extend(Evented, {
   exists(key) {
     const locale = get(this, '_locale');
     assert('ember-intl: Cannot check existance when locale is null || undefined', locale);
-    return get(this, 'adapter').findTranslationByKey(locale, key);
+    return get(this, 'adapter').has(locale, key);
   },
 
   getLocalesByTranslations() {

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -72,18 +72,25 @@ const IntlService = Service.extend(Evented, {
 
   addMessage(...args) {
     logger.warn('`addMessage` is deprecated in favor of `addTranslation`');
+
     return this.addTranslation(...args);
   },
 
   addMessages(...args) {
     logger.warn('`addMessages` is deprecated in favor of `addTranslations`');
+
     return this.addTranslations(...args);
   },
 
-  exists(key) {
-    const locale = get(this, '_locale');
-    assert('ember-intl: Cannot check existance when locale is null || undefined', locale);
-    return get(this, 'adapter').has(locale, key);
+  exists(optionalLocale, key) {
+    if (arguments.length === 1) {
+      key = optionalLocale;
+      optionalLocale = get(this, '_locale');
+    }
+
+    assert('ember-intl: Cannot check existance when locale is unset', optionalLocale);
+
+    return get(this, 'adapter').has(optionalLocale, key);
   },
 
   getLocalesByTranslations() {

--- a/addon/services/intl.js
+++ b/addon/services/intl.js
@@ -88,7 +88,7 @@ const IntlService = Service.extend(Evented, {
       optionalLocale = get(this, '_locale');
     }
 
-    assert('ember-intl: Cannot check existance when locale is unset', optionalLocale);
+    assert(`ember-intl: locale is unset, cannot confirm '${key}' exists`, optionalLocale);
 
     return get(this, 'adapter').has(optionalLocale, key);
   },

--- a/tests/unit/format-message-test.js
+++ b/tests/unit/format-message-test.js
@@ -228,22 +228,39 @@ test('locale can add message to intl service and read it', function(assert) {
 });
 
 test('locale can add messages object and can read it', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
-  const service = this.container.lookup('service:intl');
   const translation = this.container.lookup('ember-intl@translation:en-us');
   translation.addTranslations({ 'bulk-add': 'bulk add works' });
 
   view = this.render(hbs`{{format-message "bulk-add"}}`, 'en-us');
   runAppend(view);
+
   assert.equal(view.$().text(), "bulk add works");
-  assert.ok(service.exists('bulk-add'));
 });
 
+test('exists returns false when key not found', function(assert) {
+  assert.expect(1);
+
+  const service = this.container.lookup('service:intl');
+  service.setLocale('en-us');
+  const translation = this.container.lookup('ember-intl@translation:en-us');
+  translation.addTranslation('foo', 'foo');
+  assert.equal(service.exists('bar'), false);
+});
+
+test('exists returns true when key found', function(assert) {
+  assert.expect(1);
+
+  const service = this.container.lookup('service:intl');
+  const translation = this.container.lookup('ember-intl@translation:en-us');
+  translation.addTranslation('hello', 'world');
+  service.setLocale('en-us');
+  assert.equal(service.exists('hello'), true);
+});
 
 test('able to discover all register translations', function(assert) {
   assert.expect(1);
-
   const service = this.container.lookup('service:intl');
   assert.equal(service.getLocalesByTranslations().join('; '), 'en-us; es-es; fr-fr');
 });


### PR DESCRIPTION
Intl service exists method now accepts a locale argument as the first arg.  It's optional.  When unset, it will use the service's current locale.  This method now always returns a boolean.

```js
intl.exists('foo'); => true
intl.exists('en-us', 'foo') => true
intl.exists('en-us', 'bar') => false
intl.exists('bar') => false
```
