### PR TITLE
Don't lowercase the sourcemap file

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,9 +131,15 @@ module.exports = {
       trees.push(publicTree);
     }
 
+    trees.push(new Funnel(this.trees.intl, {
+      srcDir: 'dist',
+      files: ['Intl.js.map'],
+      destDir: path.join(assetPath)
+    }));
+
     trees.push(lowercaseTree(new Funnel(this.trees.intl, {
       srcDir: 'dist',
-      files: ['Intl.complete.js', 'Intl.js', 'Intl.js.map', 'Intl.min.js'],
+      files: ['Intl.complete.js', 'Intl.js', 'Intl.min.js'],
       destDir: path.join(assetPath)
     })));
 


### PR DESCRIPTION
Doing so causes an error when building with souremaps enabled in production on case-sensitive file systems.

I came across this error https://github.com/yahoo/ember-intl/issues/204 when using a version of ember-intl that included the fix. You can see a simple sample application here https://github.com/elucid/ember-intl-test that demonstrates the issue is still present when building on a case-sensitive filesystem like ext4.

As the issue mentions, Intl.js.map must be included in `treeForPublic()` but it is only picked when run on case-insensitive filesystems. This moves Intl.js.map out into its own filter which leaves the case intact. I've tested this on both case-insensitive and case-sensitive filesystems.