### PR TITLE
Removing use of path.join in index.js

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,4 +1,7 @@
+'use strict';
+
 /* global require, module */
+
 var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
 var path = require('path');
 
@@ -7,7 +10,7 @@ module.exports = function(defaults) {
     // Add options here
   });
 
-  app.options.snippetPaths = [path.join('tests', 'dummy', 'snippets')];
+  app.options.snippetPaths = ['tests/dummy/snippets'];
 
   /*
     This build file specifes the options for the dummy test app of this

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ module.exports = {
     }
 
     var intlPath = path.dirname(require.resolve('intl'));
-    var assetPath = path.join('assets', 'intl');
+    var assetPath = 'assets/intl';
     var appOptions = this.app.options;
     var trees = [];
 
@@ -110,18 +110,18 @@ module.exports = {
     trees.push(new Funnel(this.trees.intl, {
       srcDir: 'dist',
       files: ['Intl.js.map'],
-      destDir: path.join(assetPath)
+      destDir: assetPath
     }));
 
     trees.push(lowercaseTree(new Funnel(this.trees.intl, {
       srcDir: 'dist',
       files: ['Intl.complete.js', 'Intl.js', 'Intl.min.js'],
-      destDir: path.join(assetPath)
+      destDir: assetPath
     })));
 
     var localeFunnel = {
-      srcDir: path.join('locale-data', 'jsonp'),
-      destDir: path.join(assetPath, 'locales')
+      srcDir: 'locale-data/jsonp',
+      destDir: assetPath + '/locales'
     };
 
     if (this.locales.length) {
@@ -139,7 +139,7 @@ module.exports = {
   },
 
   _discoverLocales: function() {
-    var translations = path.join(this.project.root, this.addonOptions.inputPath);
+    var translations = this.project.root + '/' + this.addonOptions.inputPath;
     var locales = [];
 
     if (existsSync(translations)) {

--- a/lib/broccoli/cldr-writer.js
+++ b/lib/broccoli/cldr-writer.js
@@ -10,7 +10,6 @@
 var CachingWriter = require('broccoli-caching-writer');
 var cldr = require('formatjs-extract-cldr-data');
 var mkdirp = require('mkdirp');
-var path = require('path');
 var fs = require('fs');
 
 var assign = require('../utils/assign');
@@ -39,7 +38,7 @@ function Plugin(inputNodes, options) {
 
 Plugin.prototype.build = function() {
   var options = this.options;
-  var destPath = path.join(this.outputPath, this.path);
+  var destPath = this.outputPath + '/' + this.path;
   var wrapEntry = options.wrapEntry;
   var localesData = cldr(options);
 
@@ -52,7 +51,7 @@ Plugin.prototype.build = function() {
       result = wrapEntry(result);
     }
 
-    var outFile = path.join(destPath, localeKey.toLocaleLowerCase() + '.js');
+    var outFile = destPath + '/' + localeKey.toLocaleLowerCase() + '.js';
     var data = options.prelude + result;
     fs.writeFileSync(outFile, data, { encoding: 'utf8' });
   });

--- a/lib/broccoli/translation-preprocessor.js
+++ b/lib/broccoli/translation-preprocessor.js
@@ -80,12 +80,12 @@ function exporter(obj) {
 
 function gatherTranslations(inputPath) {
   return walkSync(inputPath).reduce(function (translations, file) {
-    var fullPath = path.join(inputPath, file);
+    var fullPath = inputPath + '/' + file;
 
     if (fs.statSync(fullPath).isDirectory()) {
       return translations;
     } else {
-      var translation = readAsObject(path.join(inputPath, file));
+      var translation = readAsObject(inputPath + '/' + file);
 
       if (!translation) {
         console.log(chalk.yellow('ember-intl: cannot read path "' + fullPath + '"'));
@@ -127,7 +127,7 @@ TranslationPreprocessor.prototype.build = function() {
 
   var inputPath = this.inputPaths[0];
 
-  var defaultTranslationPath = glob.sync(path.join(inputPath, this.options.defaultLocale) + '\.@(json|yaml|yml)', {
+  var defaultTranslationPath = glob.sync(inputPath + '/' + this.options.defaultLocale + '\.@(json|yaml|yml)', {
     nosort: true,
     silent: true
   })[0];
@@ -139,7 +139,7 @@ TranslationPreprocessor.prototype.build = function() {
 
   var translation;
 
-  var outputPath = path.join(this.outputPath, this.options.outputPath);
+  var outputPath = this.outputPath + '/' + this.options.outputPath;
   mkdirp.sync(outputPath);
 
   var translations = gatherTranslations(inputPath);
@@ -152,7 +152,7 @@ TranslationPreprocessor.prototype.build = function() {
       missedKeys(translation, defaultTranslationKeys, key);
       translation = extend(true, {}, defaultTranslation, translation);
       fs.writeFileSync(
-        path.join(outputPath, key + '.js'),
+        outputPath + '/' + key + '.js',
         exporter(translation), { encoding: 'utf8' }
       );
     }

--- a/lib/utils/is-supported-locale.js
+++ b/lib/utils/is-supported-locale.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var fs = require('fs');
 var path = require('path');
 


### PR DESCRIPTION
It's unnecessary and apparently introduces issues downstream which assumes POSIX-only style of paths

#251