### PR TITLE
makes default locale optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,20 @@ Open, or create, `app/routes/application.js` and in the `beforeModel` hook set `
       // which locale the user should be targeted and perhaps lazily
       // load translations using XHR and calling intl's `addTranslation`/`addTranslations`
       // method with the results of the XHR request
+      //
       this.get('intl').setLocale('en-us');
+
+      // OR for those that sideload, an array is accepted to handle fallback lookups
+
+      // en-ca is the primary locale, en-us is the fallback.
+      // this is optional, and likely unnecessary if you define defaultLocale (see below)
+      // The primary usecase is if you side load all translations
+      this.get('intl').setLocale(['en-ca', 'en-us']);
     }
   });
 ```
 
-* **A default locale is required**.  This is used as the "source of truth" to determine if any translations are missing a translation at build time.  It will offer warnings displaying with locale's are missing translations for a particular key.  The default locale is configurable within `config/environment.js`.
+* This is used as the "source of truth" to determine if any translations are missing a translation at build time.  It will offer warnings displaying with locale's are missing translations for a particular key.  The default locale is configurable within `config/environment.js`.
 
 ```js
 // config/environment.js

--- a/addon/adapters/-intl-adapter.js
+++ b/addon/adapters/-intl-adapter.js
@@ -8,7 +8,7 @@ import getOwner from 'ember-getowner-polyfill';
 
 import Translation from '../models/translation';
 
-const { assert, makeArray } = Ember;
+const { assert } = Ember;
 
 function normalize (fullName) {
   assert('Lookup name must be a string', typeof fullName === 'string');
@@ -27,7 +27,7 @@ const DefaultIntlAdapter = Ember.Object.extend({
     }
 
     const owner = getOwner(this);
-    const lookupName = 'ember-intl@translation:' + normalize(localeName);
+    const lookupName = `ember-intl@translation:${normalize(localeName)}`;
 
     if (!owner.hasRegistration(lookupName)) {
       owner.register(lookupName, Translation.extend({}));
@@ -46,23 +46,16 @@ const DefaultIntlAdapter = Ember.Object.extend({
     return false;
   },
 
-  findTranslationByKey(localeNames, translationKey) {
-    const locales = makeArray(localeNames);
+  findTranslationByKey(locales, translationKey) {
     const len = locales.length;
-
     let i = 0;
-    let translations, translation, key;
 
     for (; i < len; i++) {
-      key = locales[i];
-      translations = this.translationsFor(key);
+      const locale = locales[i];
+      const translations = this.translationsFor(locale);
 
-      if (translations) {
-        translation = translations.getValue(translationKey);
-
-        if (translation) {
-          return translation;
-        }
+      if (translations && translations.has(translationKey)) {
+        return translations.getValue(translationKey);
       }
     }
   }

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -28,14 +28,13 @@ function helperFactory(formatType, optionalGetValue, optionalReturnEmpty) {
 
     init(...args) {
       this._super(...args);
-      let intl = get(this, 'intl');
-      intl.on('localeChanged', this, this.recompute);
+      get(this, 'intl').on('localeChanged', this, this.recompute);
     },
 
     compute(params, hash) {
-      let intl = get(this, 'intl');
-      let formatter = get(this, 'formatter');
-      let value = this.getValue(params, hash, intl);
+      const intl = get(this, 'intl');
+      const formatter = get(this, 'formatter');
+      const value = this.getValue(params, hash, intl);
 
       if (optionalReturnEmpty && optionalReturnEmpty(value, hash)) {
         return;
@@ -43,6 +42,12 @@ function helperFactory(formatType, optionalGetValue, optionalReturnEmpty) {
 
       if (typeof value === 'undefined') {
         throw new Error(`format-${formatType} helper requires value`);
+      }
+
+      let locale = get(intl, '_locale');
+
+      if (Array.isArray(locale)) {
+        locale = locale[0];
       }
 
       let format = {};
@@ -54,7 +59,7 @@ function helperFactory(formatType, optionalGetValue, optionalReturnEmpty) {
       return formatter.format(
         value,
         extend({
-          locale: get(intl, '_locale')
+          locale: locale
         }, format, hash),
         get(intl, 'formats')
       );

--- a/app/utils/intl/missing-message.js
+++ b/app/utils/intl/missing-message.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+const { Logger:logger } = Ember;
+
+export default function missingMessage(key, locales) {
+  logger.warn(`translation: '${key}' on locale: '${locales.join(', ')}' was not found.`);
+
+  return `Missing translation: ${key}`;
+}

--- a/index.js
+++ b/index.js
@@ -28,9 +28,9 @@ function generateOptions(app) {
 
   var options = utils.assign({
     locales: undefined,
-    disablePolyfill: false,
-    defaultLocale: 'en-us',
+    defaultLocale: undefined,
     allowEmpty: true,
+    disablePolyfill: false,
     inputPath: 'translations',
     outputPath: 'translations'
   }, addonConfig);

--- a/lib/broccoli/translation-preprocessor.js
+++ b/lib/broccoli/translation-preprocessor.js
@@ -122,36 +122,38 @@ TranslationPreprocessor.prototype = Object.create(CachingWriter.prototype);
 TranslationPreprocessor.prototype.constructor = TranslationPreprocessor;
 
 TranslationPreprocessor.prototype.build = function() {
-  if (!this.options.defaultLocale) {
-    return;
-  }
-
   var inputPath = this.inputPaths[0];
-
-  var defaultTranslationPath = glob.sync(inputPath + '/' + this.options.defaultLocale + '\.@(json|yaml|yml)', {
-    nosort: true,
-    silent: true
-  })[0];
-
-  if (!defaultTranslationPath) {
-    console.log(chalk.yellow('ember-intl: "' + this.options.defaultLocale + '" default locale missing `translations` folder'));
-    return;
-  }
-
-  var translation;
-
   var outputPath = this.outputPath + '/' + this.options.outputPath;
+  var translations = gatherTranslations(inputPath);
+  var defaultTranslationKeys, defaultTranslation, translation;
+
   mkdirp.sync(outputPath);
 
-  var translations = gatherTranslations(inputPath);
-  var defaultTranslation = translations[this.options.defaultLocale];
-  var defaultTranslationKeys = propKeys(defaultTranslation);
+  if (this.options.defaultLocale) {
+    var defaultTranslationPath = glob.sync(inputPath + '/' + this.options.defaultLocale + '\.@(json|yaml|yml)', {
+      nosort: true,
+      silent: true
+    })[0];
+
+    if (!defaultTranslationPath) {
+      console.log(chalk.yellow('ember-intl: "' + this.options.defaultLocale + '" default locale missing `translations` folder'));
+      return;
+    }
+
+    defaultTranslation = translations[this.options.defaultLocale];
+    defaultTranslationKeys = propKeys(defaultTranslation);
+  }
 
   for (var key in translations) {
     if (translations.hasOwnProperty(key)) {
       translation = translations[key];
-      missedKeys(translation, defaultTranslationKeys, key);
+
+      if (this.options.defaultLocale) {
+        missedKeys(translation, defaultTranslationKeys, key);
+      }
+
       translation = extend(true, {}, defaultTranslation, translation);
+
       fs.writeFileSync(
         outputPath + '/' + key + '.js',
         exporter(translation), { encoding: 'utf8' }

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -4,6 +4,6 @@ export default Ember.Route.extend({
   intl: Ember.inject.service(),
 
   beforeModel() {
-    this.get('intl').setLocale('en-us');
+    this.get('intl').setLocale(['en-us']);
   }
 });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -13,7 +13,7 @@ module.exports = function(environment) {
     },
 
     intl: {
-      locales: ['en-us', 'es-es', 'fr-fr', 'de-de'],
+      locales: ['en-us', 'es-es', 'fr-fr', 'de-de', 'aa-dj'],
       defaultLocale: 'en-us',
       disablePolyfill: false,
       allowEmpty: true,


### PR DESCRIPTION
* This PR brings back support for defining an array for your application locale.  This array is used to resolve a translation key for the fallback case.

```
this.get('intl').setLocale([primary, secondary, fallback]);
```

* This adds a missing-message utility, similar to that of ember-i18n
* This makes default locale optional, as it would interfere with application that rely entirely on side loading translations