### PR TITLE
Adding publicOnly as a build config option, writes translations to dist only

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+progress=false

--- a/packages/ember-intl/lib/broccoli/translation-preprocessor.js
+++ b/packages/ember-intl/lib/broccoli/translation-preprocessor.js
@@ -129,18 +129,18 @@ TranslationPreprocessor.prototype.build = function() {
 
   mkdirp.sync(outputPath);
 
-  if (this.options.defaultLocale) {
-    var defaultTranslationPath = glob.sync(inputPath + '/' + this.options.defaultLocale + '\.@(json|yaml|yml)', {
+  if (this.options.baseLocale) {
+    var defaultTranslationPath = glob.sync(inputPath + '/' + this.options.baseLocale + '\.@(json|yaml|yml)', {
       nosort: true,
       silent: true
     })[0];
 
     if (!defaultTranslationPath) {
-      console.log(chalk.yellow('ember-intl: "' + this.options.defaultLocale + '" default locale missing `translations` folder'));
+      console.log(chalk.yellow('ember-intl: "' + this.options.baseLocale + '" default locale missing `translations` folder'));
       return;
     }
 
-    defaultTranslation = translations[this.options.defaultLocale];
+    defaultTranslation = translations[this.options.baseLocale];
     defaultTranslationKeys = propKeys(defaultTranslation);
   }
 
@@ -148,7 +148,7 @@ TranslationPreprocessor.prototype.build = function() {
     if (translations.hasOwnProperty(key)) {
       translation = translations[key];
 
-      if (this.options.defaultLocale) {
+      if (this.options.baseLocale) {
         missedKeys(translation, defaultTranslationKeys, key);
       }
 

--- a/packages/ember-intl/tests/dummy/config/environment.js
+++ b/packages/ember-intl/tests/dummy/config/environment.js
@@ -14,7 +14,8 @@ module.exports = function(environment) {
 
     intl: {
       locales: ['en-us', 'es-es', 'fr-fr', 'de-de', 'aa-dj'],
-      defaultLocale: 'en-us',
+      baseLocale: 'en-us',
+      publicOnly: false,
       disablePolyfill: false,
       allowEmpty: true,
       outputPath: 'translations',

--- a/packages/ember-intl/tests/unit/helpers/format-date-test.js
+++ b/packages/ember-intl/tests/unit/helpers/format-date-test.js
@@ -11,7 +11,7 @@ import { runAppend, runDestroy } from '../../helpers/run-append';
 import createRenderer from '../../helpers/create-intl-block';
 
 const date = 1390518044403;
-const defaultLocale = 'en-us';
+const locale = 'en-us';
 
 let view;
 
@@ -35,42 +35,42 @@ test('invoke the formatDate directly', function(assert) {
   const service = this.container.lookup('service:intl');
   assert.equal(service.formatDate(date, {
     timeZone: 'UTC',
-    locale: defaultLocale
+    locale: locale
   }), '1/23/2014');
 });
 
 test('should render empty string for a null value', function(assert) {
   assert.expect(1);
-  view = this.render(hbs`{{format-date null}}`, defaultLocale);
+  view = this.render(hbs`{{format-date null}}`, locale);
   runAppend(view);
   assert.equal(view.$().text(), '');
 });
 
 test('should render empty string for an empty string value', function(assert) {
   assert.expect(1);
-  view = this.render(hbs`{{format-date ''}}`, defaultLocale);
+  view = this.render(hbs`{{format-date ''}}`, locale);
   runAppend(view);
   assert.equal(view.$().text(), '');
 });
 
 test('should render empty string for an undefined value', function(assert) {
   assert.expect(1);
-  view = this.render(hbs`{{format-date undefined}}`, defaultLocale);
+  view = this.render(hbs`{{format-date undefined}}`, locale);
   runAppend(view);
   assert.equal(view.$().text(), '');
 });
 
 test('should render epoch date for a null value when allow empty is false', function(assert) {
   assert.expect(1);
-  view = this.render(hbs`{{format-date null allowEmpty=false}}`, defaultLocale);
+  view = this.render(hbs`{{format-date null allowEmpty=false}}`, locale);
   runAppend(view);
-  assert.equal(view.$().text(), new Intl.DateTimeFormat(defaultLocale).format(0));
+  assert.equal(view.$().text(), new Intl.DateTimeFormat(locale).format(0));
 });
 
 test('it should return a formatted string from a date string', function(assert) {
   assert.expect(1);
   // Must provide `timeZone` because: https://github.com/yahoo/ember-intl/issues/21
-  view = this.render(hbs`{{format-date date timeZone='UTC'}}`, defaultLocale);
+  view = this.render(hbs`{{format-date date timeZone='UTC'}}`, locale);
   view.set('context', { date: date });
   runAppend(view);
   assert.equal(view.$().text(), '1/23/2014');
@@ -79,7 +79,7 @@ test('it should return a formatted string from a date string', function(assert) 
 test('it should return a formatted string from a timestamp', function(assert) {
   assert.expect(1);
   // Must provide `timeZone` because: https://github.com/yahoo/ember-intl/issues/21
-  view = this.render(hbs`{{format-date date timeZone='UTC'}}`, defaultLocale);
+  view = this.render(hbs`{{format-date date timeZone='UTC'}}`, locale);
   view.set('context', { date: date });
   runAppend(view);
   assert.equal(view.$().text(), '1/23/2014');
@@ -87,7 +87,7 @@ test('it should return a formatted string from a timestamp', function(assert) {
 
 test('it should return a formatted string of just the date', function(assert) {
   assert.expect(1);
-  view = this.render(hbs`{{format-date date hour='numeric' minute='numeric' timeZone='UTC'}}`, defaultLocale);
+  view = this.render(hbs`{{format-date date hour='numeric' minute='numeric' timeZone='UTC'}}`, locale);
   view.set('context', { date: date });
   runAppend(view);
   assert.equal(view.$().text(), '11:00 PM');
@@ -95,7 +95,7 @@ test('it should return a formatted string of just the date', function(assert) {
 
 test('it should format the epoch timestamp', function(assert) {
   assert.expect(1);
-  view = this.render(hbs`{{format-date 0}}`, defaultLocale);
+  view = this.render(hbs`{{format-date 0}}`, locale);
   runAppend(view);
-  assert.equal(view.$().text(), new Intl.DateTimeFormat(defaultLocale).format(0));
+  assert.equal(view.$().text(), new Intl.DateTimeFormat(locale).format(0));
 });


### PR DESCRIPTION
This allows for consumers of the application to still manage their translations through ember-intl but ember-intl will not package any of the translations with the app code.  This improves the side-loading story.