### PR TITLE
Creates a standalone config file

### DIFF
--- a/packages/ember-intl/app/instance-initializers/ember-intl.js
+++ b/packages/ember-intl/app/instance-initializers/ember-intl.js
@@ -5,9 +5,9 @@
 
 import ENV from '../config/environment';
 
-function filterBy(env, type) {
+function filterBy(type) {
   return Object.keys(requirejs._eak_seen).filter((key) => {
-    return key.indexOf(`${env.modulePrefix}\/${type}\/`) === 0;
+    return key.indexOf(`${ENV.modulePrefix}\/${type}\/`) === 0;
   });
 }
 
@@ -15,11 +15,11 @@ export function instanceInitializer(instance) {
   const container = instance.lookup ? instance : instance.container;
   const service = container.lookup('service:intl');
 
-  filterBy(ENV, 'cldrs').forEach((key) => {
+  filterBy('cldrs').forEach((key) => {
     service.addLocaleData(require(key, null, null, true)['default']);
   });
 
-  filterBy(ENV, 'translations').forEach((key) => {
+  filterBy('translations').forEach((key) => {
     const localeSplit = key.split('\/');
     const localeName = localeSplit[localeSplit.length - 1];
     service.addTranslations(localeName, require(key, null, null, true)['default']);

--- a/packages/ember-intl/app/instance-initializers/ember-intl.js
+++ b/packages/ember-intl/app/instance-initializers/ember-intl.js
@@ -1,9 +1,12 @@
+/* globals requirejs */
+
 /**
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
 import ENV from '../config/environment';
+import getOwner from 'ember-getowner-polyfill';
 
 function filterBy(type) {
   return Object.keys(requirejs._eak_seen).filter((key) => {
@@ -12,8 +15,7 @@ function filterBy(type) {
 }
 
 export function instanceInitializer(instance) {
-  const container = instance.lookup ? instance : instance.container;
-  const service = container.lookup('service:intl');
+  const service = getOwner(instance).lookup('service:intl');
 
   filterBy('cldrs').forEach((key) => {
     service.addLocaleData(require(key, null, null, true)['default']);

--- a/packages/ember-intl/blueprints/ember-intl-config/files/config/ember-intl.js
+++ b/packages/ember-intl/blueprints/ember-intl-config/files/config/ember-intl.js
@@ -2,11 +2,52 @@
 
 module.exports = function(environment) {
   return {
+    /**
+    * The locales that are application supports.
+    *
+    * This is optional and is automatically set if project stores translations
+    * where ember-intl is able to look them up (<project root>/translations/).
+    *
+    * If the project relies on side-loading translations, then you must explicitly
+    * list out the locales. i.e: ['en-us', 'en-gb', 'fr-fr']
+    *
+    * @property locales
+    * @type {Array?}
+    * @default "null"
+    */
     locales: null,
+
+    /**
+    * baseLocale is used to determine if translation keys are missing from other locales.
+    * This is property is optional, and if you rely on sideloading translations then
+    * this should be null
+    *
+    * @property baseLocale
+    * @type {String?}
+    * @default "null"
+    */
     baseLocale: null,
+
+    /**
+    * disablePolyfill prevents the polyfill from being bundled in the asset folder of the build
+    *
+    * @property disablePolyfill
+    * @type {Boolean}
+    * @default "false"
+    */
     disablePolyfill: false,
-    publicOnly: false,
-    inputPath: 'translations',
-    outputPath: 'translations'
+
+    /**
+    * prevents the translations from being bundled with the application code.
+    * This enables asynchronously loading the translations for the active locale
+    * by fetching them from the asset folder of the build.
+    *
+    * See: https://github.com/yahoo/ember-intl/wiki/Asynchronously-loading-translations
+    *
+    * @property publicOnly
+    * @type {Boolean}
+    * @default "false"
+    */
+    publicOnly: false
   };
 };

--- a/packages/ember-intl/config/ember-intl.js
+++ b/packages/ember-intl/config/ember-intl.js
@@ -2,11 +2,52 @@
 
 module.exports = function(environment) {
   return {
+    /**
+    * The locales that are application supports.
+    *
+    * This is optional and is automatically set if project stores translations
+    * where ember-intl is able to look them up (<project root>/translations/).
+    *
+    * If the project relies on side-loading translations, then you must explicitly
+    * list out the locales. i.e: ['en-us', 'en-gb', 'fr-fr']
+    *
+    * @property locales
+    * @type {Array?}
+    * @default "null"
+    */
     locales: null,
+
+    /**
+    * baseLocale is used to determine if translation keys are missing from other locales.
+    * This is property is optional, and if you rely on sideloading translations then
+    * this should be null
+    *
+    * @property baseLocale
+    * @type {String?}
+    * @default "null"
+    */
     baseLocale: null,
+
+    /**
+    * disablePolyfill prevents the polyfill from being bundled in the asset folder of the build
+    *
+    * @property disablePolyfill
+    * @type {Boolean}
+    * @default "false"
+    */
     disablePolyfill: false,
-    publicOnly: false,
-    inputPath: 'translations',
-    outputPath: 'translations'
+
+    /**
+    * prevents the translations from being bundled with the application code.
+    * This enables asynchronously loading the translations for the active locale
+    * by fetching them from the asset folder of the build.
+    *
+    * See: https://github.com/yahoo/ember-intl/wiki/Asynchronously-loading-translations
+    *
+    * @property publicOnly
+    * @type {Boolean}
+    * @default "false"
+    */
+    publicOnly: false
   };
 };

--- a/packages/ember-intl/index.js
+++ b/packages/ember-intl/index.js
@@ -8,9 +8,10 @@
  */
 
 var serialize = require('serialize-javascript');
-var Funnel = require('broccoli-funnel');
-var WatchedDir = require('broccoli-source').WatchedDir;
+var stringify = require('json-stable-stringify');
 var UnwatchedDir = require('broccoli-source').UnwatchedDir;
+var WatchedDir = require('broccoli-source').WatchedDir;
+var Funnel = require('broccoli-funnel');
 var existsSync = require('exists-sync');
 var stew = require('broccoli-stew');
 var walkSync = require('walk-sync');
@@ -118,7 +119,13 @@ module.exports = {
 
     if (this.hasTranslationDir && !this._intlConfig.publicOnly) {
       trees.push(new TranslationPreprocessor(this.trees.translations, utils.assign({
-        ui: this.ui
+        ui: this.ui,
+        filename: function filename(key) {
+          return key + '.js';
+        },
+        wrapEntry: function wrapEntry(obj) {
+          return 'export default ' + stringify(obj) + ';';
+        }
       }, this._intlConfig)));
     }
 
@@ -140,7 +147,6 @@ module.exports = {
 
   treeForPublic: function() {
     var publicTree = this._super.treeForPublic.apply(this, arguments);
-
     var trees = [];
 
     if (publicTree) {

--- a/packages/ember-intl/tests/dummy/config/ember-intl.js
+++ b/packages/ember-intl/tests/dummy/config/ember-intl.js
@@ -2,8 +2,57 @@
 
 module.exports = function(environment) {
   return {
+    /**
+    * The locales that are application supports.
+    *
+    * This is optional and is automatically set if project stores translations
+    * where ember-intl is able to look them up (<project root>/translations/).
+    *
+    * If the project relies on side-loading translations, then you must explicitly
+    * list out the locales. i.e: ['en-us', 'en-gb', 'fr-fr']
+    *
+    * @property locales
+    * @type {Array?}
+    * @default "null"
+    */
     locales: ['en-us', 'es-es', 'fr-fr', 'de-de', 'aa-dj'],
+
+    /**
+    * baseLocale is used to determine if translation keys are missing from other locales.
+    * This is property is optional, and if you rely on sideloading translations then
+    * this should be null
+    *
+    * @property baseLocale
+    * @type {String?}
+    * @default "null"
+    */
     baseLocale: 'en-us',
+
+    /**
+    * disablePolyfill prevents the polyfill from being bundled in the asset folder of the build
+    *
+    * @property disablePolyfill
+    * @type {Boolean}
+    * @default "false"
+    */
+    disablePolyfill: false,
+
+    /**
+    * prevents the translations from being bundled with the application code.
+    * This enables asynchronously loading the translations for the active locale
+    * by fetching them from the asset folder of the build.
+    *
+    * See: https://github.com/yahoo/ember-intl/wiki/Asynchronously-loading-translations
+    *
+    * @property publicOnly
+    * @type {Boolean}
+    * @default "false"
+    */
+    publicOnly: false,
+
+    /**
+    * @private
+    */
     inputPath: 'tests/dummy/translations'
   };
 };


### PR DESCRIPTION
This also fixes a bug where `publicOnly` set to true would write ES6 syntax in the translation files.  It now writes json files to the public folder, ES6 internally on the app tree.